### PR TITLE
Added processDate support to Transaction::refund call

### DIFF
--- a/src/Api/Transaction/Refund.php
+++ b/src/Api/Transaction/Refund.php
@@ -43,6 +43,10 @@ class Refund extends Transaction
      * @var string the description for this refund
      */
     private $description;
+    /**
+     * @var \DateTime the date the refund should take place
+     */
+    private $processDate;
 
     /**
      * Get data to send to the api
@@ -59,6 +63,10 @@ class Refund extends Transaction
 
         if (!empty($this->amount)) {
             $this->data['amount'] = $this->amount;
+        }
+
+        if (!empty($this->processDate)) {
+            $this->data['processDate'] = $this->processDate->format('d-m-Y');
         }
 
         return parent::getData();
@@ -86,6 +94,14 @@ class Refund extends Transaction
     public function setDescription($description)
     {
         $this->description = $description;
+    }
+
+    /**
+     * @param \DateTime $processDate
+     */
+    public function setProcessDate(\DateTime $processDate)
+    {
+        $this->processDate = $processDate;
     }
 
     /**

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -290,11 +290,12 @@ class Transaction
      * @param string $transactionId
      * @param int|float|null $amount
      * @param string|null $description
+     * @param \DateTime $processDate
      *
      * @return Result\Refund
      */
     public static function refund($transactionId, $amount = null,
-                                  $description = null)
+                                  $description = null, \DateTime $processDate = null)
     {
         $api = new Api\Refund();
         $api->setTransactionId($transactionId);
@@ -305,6 +306,10 @@ class Transaction
 
         if (!is_null($description)) {
             $api->setDescription($description);
+        }
+
+        if (!is_null($processDate)) {
+            $api->setProcessDate($processDate);
         }
         $result = $api->doRequest();
 

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -251,7 +251,7 @@ class TransactionTest extends PHPUnit_Framework_TestCase
         \Paynl\Config::setApiToken('123456789012345678901234567890');
 
         $this->setDummyData('Result/transactionVerify');
-s
+
         $transaction = Paynl\Transaction::get('12456789');
 
         $this->setDummyData('Result/approve');

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -245,13 +245,13 @@ class TransactionTest extends PHPUnit_Framework_TestCase
         $this->setExpectedException('\Paynl\Error\Api');
 
         $this->setDummyData('Result/refundError');
-        \Paynl\Transaction::refund('645958819Xdd3ea1', 5, 'Description');
+        \Paynl\Transaction::refund('645958819Xdd3ea1', 5, 'Description', new DateTime());
     }
     public function testApprove(){
         \Paynl\Config::setApiToken('123456789012345678901234567890');
 
         $this->setDummyData('Result/transactionVerify');
-
+s
         $transaction = Paynl\Transaction::get('12456789');
 
         $this->setDummyData('Result/approve');


### PR DESCRIPTION
Allows for setting processDate on refund calls, so you can put refunds in the future. This would allow for stricter control on automatically generated refunds as staff can review scheduled refunds in the admin panel, and for example cancel them if they think in was unjust.

Error handling on validity of the date is up to the pay.nl server i guess?
if you want me to add some kind of validation, let me know what valid dates are.