### PR TITLE
fixed various style inconsistencies:

### DIFF
--- a/samples/directDebit/add.php
+++ b/samples/directDebit/add.php
@@ -2,7 +2,7 @@
 require_once '../../vendor/autoload.php';
 require_once '../config.php';
 try {
-    $result = Paynl\DirectDebit::add(array(
+    $result = Paynl\DirectDebit::add([
         'amount' => 0.1,
         'bankaccountHolder' => 'N. Klant',
         'bankaccountNumber' => 'NL00RAB0123456789',
@@ -22,7 +22,7 @@ try {
         'extra2' => 'extra2',
         'extra3' => 'extra3',
         'currency' => 'EUR',
-    ));
+    ]);
     echo $result->getMandateId();
 } catch (\Paynl\Error\Error $e){
     echo "Error: ".$e->getMessage();

--- a/samples/directDebit/mandate/add.php
+++ b/samples/directDebit/mandate/add.php
@@ -2,7 +2,7 @@
 require_once '../../../vendor/autoload.php';
 require_once '../../config.php';
 try {
-    $result = Paynl\DirectDebit\Mandate::add(array(
+    $result = Paynl\DirectDebit\Mandate::add([
         'amount' => 0.1,
         'bankaccountHolder' => 'N. Klant',
         'bankaccountNumber' => 'NL00RABO0123456789',
@@ -22,7 +22,7 @@ try {
         'extra2' => 'extra2',
         'extra3' => 'extra3',
         'currency' => 'EUR',
-    ));
+    ]);
     echo $result->getMandateId();
 } catch (\Paynl\Error\Error $e){
     echo "Error: ".$e->getMessage();

--- a/samples/directDebit/mandate/addTransaction.php
+++ b/samples/directDebit/mandate/addTransaction.php
@@ -2,12 +2,12 @@
 require_once '../../../vendor/autoload.php';
 require_once '../../config.php';
 try {
-    $result = Paynl\DirectDebit\Mandate::addTransaction(array(
+    $result = Paynl\DirectDebit\Mandate::addTransaction([
         'mandateId' => 'IO-6604-2112-1710',
         'amount' => 0.10,
         'description' => 'Handmatig herhaald',
         'processDate' => new DateTime('tomorrow'),
-    ));
+    ]);
     var_dump($result->getData());
 } catch (\Paynl\Error\Error $e){
     echo "Error: ".$e->getMessage();

--- a/samples/directDebit/recurring/add.php
+++ b/samples/directDebit/recurring/add.php
@@ -2,7 +2,7 @@
 require_once '../../../vendor/autoload.php';
 require_once '../../config.php';
 try {
-    $result = Paynl\DirectDebit\Recurring::add(array(
+    $result = Paynl\DirectDebit\Recurring::add([
         'amount' => 0.1,
         'bankaccountHolder' => 'N Klant',
         'bankaccountNumber' => 'NL00RABO0123456789',
@@ -25,7 +25,7 @@ try {
         'extra2' => 'extra2',
         'extra3' => 'extra3',
         'currency' => 'EUR',
-    ));
+    ]);
     echo $result->getMandateId();
 } catch (\Paynl\Error\Error $e){
     echo "Error: ".$e->getMessage();

--- a/samples/instore/confirmPayment.php
+++ b/samples/instore/confirmPayment.php
@@ -24,12 +24,11 @@ $emailAddress = @$_GET['emailAddress'];
 $languageId = @$_GET['languageId'];
 
 try {
-    $result = \Paynl\Instore::confirmPayment(array(
+    $result = \Paynl\Instore::confirmPayment([
         'hash' => $hash,
         'emailAddress' => $emailAddress,
         'languageId' => $languageId
-    ));
-
+    ]);
     var_dump($result->getData());
 } catch (\Paynl\Error\Error $e) {
     echo "Fout: " . $e->getMessage();

--- a/samples/instore/getReceipt.php
+++ b/samples/instore/getReceipt.php
@@ -22,7 +22,7 @@ require_once '../config.php';
 $hash = $_GET['hash']; //The hash you get from instore/payment
 
 try {
-    $result = \Paynl\Instore::getReceipt(array('hash' => $hash));
+    $result = \Paynl\Instore::getReceipt(['hash' => $hash]);
     echo nl2br($result->getReceipt());
 } catch (\Paynl\Error\Error $e) {
     echo "Fout: " . $e->getMessage();

--- a/samples/instore/payment.php
+++ b/samples/instore/payment.php
@@ -23,10 +23,10 @@ $transactionId = $_GET['transactionId']; // The transactionId you get from trans
 $terminalId = $_GET['terminalId']; // the terminalId you get from getAllTerminals
 
 try {
-    $result = \Paynl\Instore::payment(array(
+    $result = \Paynl\Instore::payment([
         'transactionId' => $transactionId,
         'terminalId' => $terminalId
-    ));
+    ]);
 
     $hash = $result->getHash();
 

--- a/samples/instore/status.php
+++ b/samples/instore/status.php
@@ -22,7 +22,7 @@ require_once '../config.php';
 $hash = $_GET['hash']; //The hash you get from instore/payment
 
 try {
-    $result = \Paynl\Instore::status(array('hash' => $hash));
+    $result = \Paynl\Instore::status(['hash' => $hash]);
 
     var_dump($result->getData());
 } catch (\Paynl\Error\Error $e) {

--- a/samples/transaction/addRecurring.php
+++ b/samples/transaction/addRecurring.php
@@ -20,14 +20,14 @@ require_once '../../vendor/autoload.php';
 require_once '../config.php';
 
 try {
-    $result = \Paynl\Transaction::addRecurring(array(
+    $result = \Paynl\Transaction::addRecurring([
         'transactionId' => '12345678Xbf1234',
         'amount' => 0.01,
         'description' => 'Your recurring payment',
         'extra1' => 'SDK',
         'extra2' => 'extra2',
         'extra3' => 'extra3'
-    ));
+    ]);
 
     echo $result->getTransactionId();
 } catch (\Paynl\Error\Error $e) {

--- a/samples/transaction/start-minimum.php
+++ b/samples/transaction/start-minimum.php
@@ -20,7 +20,7 @@ require_once '../../vendor/autoload.php';
 require_once '../config.php';
 
 try {
-    $result = \Paynl\Transaction::start(array(
+    $result = \Paynl\Transaction::start([
     	// Required
         'amount' => 12.5,
         'returnUrl' => dirname(Paynl\Helper::getBaseUrl()) . '/return.php',
@@ -30,7 +30,7 @@ try {
         'exchangeUrl' => dirname(Paynl\Helper::getBaseUrl()) . '/exchange.php',
         'paymentMethod' => 10,// iDEAL use \Paynl\PaymentMethods::getList() to get all available paymentmethods
         'description' => '123456', // the transaction description, usually the orderId
-    ));
+    ]);
 
 	// Save this transactionId and link it to your order
     $transactionId = $result->getTransactionId();

--- a/samples/transaction/start.php
+++ b/samples/transaction/start.php
@@ -20,7 +20,7 @@ require_once '../../vendor/autoload.php';
 require_once '../config.php';
 
 try {
-    $result = \Paynl\Transaction::start(array(
+    $result = \Paynl\Transaction::start([
         // required
         'amount' => 12.5,
         'returnUrl' => dirname(Paynl\Helper::getBaseUrl()) . '/return.php',
@@ -39,50 +39,50 @@ try {
         'ipaddress' => '10.0.0.1',
         'invoiceDate' => new DateTime('now'),
         'deliveryDate' => new DateTime('2016-06-06'), // in case of tickets for an event, use the event date here
-        'products' => array(
-            array(
+        'products' => [
+            [
                 'id' => 1,
                 'name' => 'een product',
                 'price' => 5,
                 'vatPercentage' => 21,
                 'qty' => 1,
                 'type' => \Paynl\Transaction::PRODUCT_TYPE_ARTICLE
-            ),
-            array(
+            ],
+            [
                 'id' => 2,
                 'name' => 'ander product 15 %',
                 'price' => 5,
                 'vatPercentage' => 15,
                 'qty' => 1,
                 'type' => \Paynl\Transaction::PRODUCT_TYPE_ARTICLE
-            ),
-            array(
+            ],
+            [
                 'id' => 'shipping',
                 'name' => 'verzendkosten',
                 'price' => 5,
                 'vatPercentage' => 21,
                 'qty' => 1,
                 'type' => \Paynl\Transaction::PRODUCT_TYPE_SHIPPING
-            ),
-            array(
+            ],
+            [
                 'id' => 'fee',
                 'name' => 'Handling fee',
                 'price' => 1,
                 'vatPercentage' => 21,
                 'qty' => 1,
                 'type' => \Paynl\Transaction::PRODUCT_TYPE_HANDLING
-            ),
-            array(
+            ],
+            [
                 'id' => '5543',
                 'name' => 'Coupon 3,50 korting',
                 'price' => -3.5,
                 'vatPercentage' => 21,
                 'qty' => 1,
                 'type' => \Paynl\Transaction::PRODUCT_TYPE_DISCOUNT
-            ),
-        ),
+            ],
+        ],
         'language' => 'EN',
-        'enduser' => array(
+        'enduser' => [
             'initials' => 'T',
             'lastName' => 'Test',
             'gender' => 'M',
@@ -91,22 +91,22 @@ try {
             'emailAddress' => 'test@test.nl',
             'customerReference' => '456789',//your customer id
             'customerTrust' => 0, // -10 - 10 how much do you trust this customer? -10 untrustable 10 trusted
-        ),
-        'address' => array(
+        ],
+        'address' => [
             'streetName' => 'Test',
             'houseNumber' => '10',
             'houseNumberExtension' => 'A',
             'zipCode' => '1234AB',
             'city' => 'Test',
             'country' => 'NL',
-        ),
-        'company' => array(
+        ],
+        'company' => [
             'name' => 'CompanyName',
             'cocNumber' => '12345678',
             'vatNumber' => 'NL0123456789',
             'countryCode' => 'NL'
-        ),
-        'invoiceAddress' => array(
+        ],
+        'invoiceAddress' => [
             'initials' => 'IT',
             'lastName' => 'ITEST',
             'streetName' => 'Istreet',
@@ -115,7 +115,7 @@ try {
             'zipCode' => '5678CD',
             'city' => 'ITest',
             'country' => 'NL',
-        ),
+        ],
 
         // Only use this if you are told to
 //        'transferType' => 'merchant',
@@ -123,7 +123,7 @@ try {
 //
 //        'transferType' => 'transaction',
 //        'transferValue' => '12345678X260bc5', // The transactionId
-    ));
+    ]);
 
 // Save this transactionid and link it to your order
     $transactionId = $result->getTransactionId();

--- a/samples/validate/isPayServerIp.php
+++ b/samples/validate/isPayServerIp.php
@@ -20,10 +20,10 @@ require_once '../../vendor/autoload.php';
 require_once '../config.php';
 
 try {
-    $results = array();
-
-    $results[] = \Paynl\Validate::isPayServerIp('12.34.56.78'); // not a pay server ip
-    $results[] = \Paynl\Validate::isPayServerIp('37.46.137.135'); // pay server ip
+    $results = [
+      \Paynl\Validate::isPayServerIp('12.34.56.78'), // not a pay server ip
+      \Paynl\Validate::isPayServerIp('37.46.137.135'), // pay server ip
+    ];
 
     var_dump($results);
 } catch (\Paynl\Error\Error $e) {

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -29,9 +29,15 @@ use Paynl\Helper;
  */
 class Api
 {
+    /**
+     * @var int the version of the api
+     */
     protected $version = 1;
 
-    protected $data = array();
+    /**
+     * @var array
+     */
+    protected $data = [];
 
     /**
      * @var bool Is the ApiToken required for this API
@@ -42,31 +48,45 @@ class Api
      */
     protected $serviceIdRequired = false;
 
+    /**
+     * @return bool
+     */
     public function isApiTokenRequired()
     {
         return $this->apiTokenRequired;
     }
 
+    /**
+     * @return bool
+     */
     public function isServiceIdRequired()
     {
         return $this->serviceIdRequired;
     }
 
+    /**
+     * @return array
+     * @throws Error\Required\ApiToken
+     * @throws Error\Required\ServiceId
+     */
     protected function getData()
     {
         if($this->isApiTokenRequired()) {
             Helper::requireApiToken();
-
             $this->data['token'] = Config::getApiToken();
         }
         if($this->isServiceIdRequired()){
             Helper::requireServiceId();
-
             $this->data['serviceId'] = Config::getServiceId();
         }
         return $this->data;
     }
 
+    /**
+     * @param object|array $result
+     * @return array
+     * @throws Error\Api
+     */
     protected function processResult($result)
     {
         $output = Helper::objectToArray($result);
@@ -75,22 +95,29 @@ class Api
             throw new Error\Api($output);
         }
 
-        if ($output['request']['result'] != 1 && $output['request']['result'] != 'TRUE') {
+        if ($output['request']['result'] != 1 && $output['request']['result'] !== 'TRUE') {
             throw new Error\Api($output['request']['errorId'] . ' - ' . $output['request']['errorMessage']);
         }
         return $output;
     }
 
+    /**
+     * @param $endpoint
+     * @param null|int $version
+     * @return array
+     *
+     * @throws Error\Api
+     * @throws Error\Error
+     */
     public function doRequest($endpoint, $version = null)
     {
-        if(is_null($version)){
+        if($version === null){
             $version = $this->version;
         }
 
         $data = $this->getData();
 
-
-        $uri = Config::getApiUrl($endpoint, $version);
+        $uri = Config::getApiUrl($endpoint, (int) $version);
 
         $curl = Config::getCurl();
 
@@ -99,22 +126,19 @@ class Api
             $curl->setOpt(CURLOPT_CAINFO, Config::getCAInfoLocation());
         }
 
-        $verifyPeer = Config::getVerifyPeer();
-        $curl->setOpt(CURLOPT_SSL_VERIFYPEER, $verifyPeer);
+        $curl->setOpt(CURLOPT_SSL_VERIFYPEER, Config::getVerifyPeer());
 
         $result = $curl->post($uri, $data);
 
         if($curl->error){
             if(!empty($result)) {
-                if ($result->status == "FALSE") {
+                if ($result->status === 'FALSE') {
                     throw new Error\Api($result->error);
                 }
             }
             throw new Error\Error($curl->errorMessage);
         }
 
-        $output = static::processResult($result);
-
-        return $output;
+        return $this->processResult($result);
     }
 }

--- a/src/Api/Currency/Currency.php
+++ b/src/Api/Currency/Currency.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 6-7-16
- * Time: 17:55
- */
 
 namespace Paynl\Api\Currency;
 
@@ -15,9 +9,11 @@ use Paynl\Helper;
 class Currency extends Api
 {
     protected $apiTokenRequired = true;
-
     protected $version = 2;
 
+    /**
+     * @inheritdoc
+     */
     protected function processResult($result)
     {
         $output = Helper::objectToArray($result);

--- a/src/Api/Currency/GetAll.php
+++ b/src/Api/Currency/GetAll.php
@@ -1,16 +1,12 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 6-7-16
- * Time: 17:57
- */
 
 namespace Paynl\Api\Currency;
 
-
 class GetAll extends Currency
 {
+    /**
+     * @inheritdoc
+     */
     public function doRequest($endpoint = null, $version = null)
     {
         return parent::doRequest('Currency/getAll', $version);

--- a/src/Api/DirectDebit/DebitAdd.php
+++ b/src/Api/DirectDebit/DebitAdd.php
@@ -239,27 +239,32 @@ class DebitAdd extends DirectDebit
         $this->_exchangeUrl = $exchangeUrl;
     }
 
+    /**
+     * @inheritdoc
+     * @throws Required amount is required
+     * @throws Required bankaccountHolder is required
+     * @throws Required bankaccountnumber is required
+     */
     public function getData()
     {
         if (empty($this->_amount)) {
-            throw new Required('amount');
-        } else {
-            $this->data['amount'] = $this->_amount;
+            throw new Required('amount is required');
         }
         if (empty($this->_bankaccountHolder)) {
-            throw new Required('bankaccountHolder');
-        } else {
-            $this->data['bankaccountHolder'] = $this->_bankaccountHolder;
+            throw new Required('bankaccountHolder is required');
         }
         if (empty($this->_bankaccountNumber)) {
-            throw new Required('bankaccountnumber');
-        } else {
-            $this->data['bankaccountnumber'] = $this->_bankaccountNumber;
+            throw new Required('bankaccountnumber is required');
         }
+
+        $this->data['amount'] = $this->_amount;
+        $this->data['bankaccountHolder'] = $this->_bankaccountHolder;
+        $this->data['bankaccountnumber'] = $this->_bankaccountNumber;
+
         if (!empty($this->_bankaccountBic)) {
             $this->data['bankaccountBic'] = $this->_bankaccountBic;
         }
-        if (!empty($this->_processDate)) {
+        if ($this->_processDate instanceof \DateTime) {
             $this->data['processDate'] = $this->_processDate->format('d-m-Y');
         }
         if (!empty($this->_description)) {
@@ -309,7 +314,7 @@ class DebitAdd extends DirectDebit
      */
     public function doRequest($endpoint = 'DirectDebit/debitAdd', $version = null)
     {
-        if (is_null($version)) {
+        if ($version === null) {
             $version = $this->version;
         }
         return parent::doRequest($endpoint, $version);

--- a/src/Api/DirectDebit/DebitGet.php
+++ b/src/Api/DirectDebit/DebitGet.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 7-7-16
- * Time: 15:51
- */
 
 namespace Paynl\Api\DirectDebit;
-
 
 use Paynl\Error\Required;
 
@@ -28,6 +21,10 @@ class DebitGet extends DirectDebit
         $this->_mandateId = $mandateId;
     }
 
+    /**
+     * @inheritdoc
+     * @throws Required mandateId is required
+     */
     public function getData()
     {
         if(empty($this->_mandateId)){
@@ -39,6 +36,9 @@ class DebitGet extends DirectDebit
         return parent::getData();
     }
 
+    /**
+     * @inheritdoc
+     */
     public function doRequest($endpoint = null, $version = null)
     {
         return parent::doRequest('DirectDebit/debitGet');

--- a/src/Api/DirectDebit/Delete.php
+++ b/src/Api/DirectDebit/Delete.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 13-7-16
- * Time: 19:55
- */
 
 namespace Paynl\Api\DirectDebit;
-
 
 use Paynl\Error\Required;
 
@@ -26,16 +19,24 @@ class Delete extends DirectDebit
         $this->_mandateId = $mandateId;
     }
 
+    /**
+     * @inheritdoc
+     * @throws Required mandateId is required
+     */
     protected function getData()
     {
         if(empty($this->_mandateId)){
             throw new Required('mandateId');
-        } else {
-            $this->data['mandateId'] = $this->_mandateId;
         }
+
+        $this->data['mandateId'] = $this->_mandateId;
 
         return parent::getData();
     }
+
+    /**
+     * @inheritdoc
+     */
     public function doRequest($endpoint = null, $version = null)
     {
         return parent::doRequest('DirectDebit/delete');

--- a/src/Api/DirectDebit/DirectDebit.php
+++ b/src/Api/DirectDebit/DirectDebit.php
@@ -29,17 +29,4 @@ class DirectDebit extends Api
      * @var int the version of the api
      */
     protected $version = 3;
-
-    /**
-     * @param string $endpoint
-     * @param int|null $version
-     * @return array The result
-     */
-    public function doRequest($endpoint, $version = null)
-    {
-        if (is_null($version)) {
-            $version = $this->version;
-        }
-        return parent::doRequest($endpoint, $version);
-    }
 }

--- a/src/Api/DirectDebit/MandateAdd.php
+++ b/src/Api/DirectDebit/MandateAdd.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 6-7-16
- * Time: 16:06
- */
 
 namespace Paynl\Api\DirectDebit;
-
 
 class MandateAdd extends DebitAdd
 {
@@ -24,6 +17,9 @@ class MandateAdd extends DebitAdd
         $this->_intervalQuantity = $intervalQuantity;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getData()
     {
         if(!empty($this->_intervalQuantity)){
@@ -32,6 +28,9 @@ class MandateAdd extends DebitAdd
         return parent::getData();
     }
 
+    /**
+     * @inheritdoc
+     */
     public function doRequest($endpoint = 'DirectDebit/mandateAdd', $version = null)
     {
         return parent::doRequest($endpoint, $version);

--- a/src/Api/DirectDebit/MandateDebit.php
+++ b/src/Api/DirectDebit/MandateDebit.php
@@ -1,19 +1,13 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 7-7-16
- * Time: 15:58
- */
 
 namespace Paynl\Api\DirectDebit;
-
 
 use Paynl\Error\Required;
 
 class MandateDebit extends DirectDebit
 {
     protected $apiTokenRequired = true;
+
     /**
      * @var string The mandateId (IO-xxxx-xxxx-xxxx)
      */
@@ -75,26 +69,34 @@ class MandateDebit extends DirectDebit
         $this->_last = $last;
     }
 
+    /**
+     * @inheritdoc
+     * @throws Required mandateId is required
+     */
     protected function getData()
     {
         if (empty($this->_mandateId)) {
             throw new Required('mandateId');
-        } else {
-            $this->data['mandateId'] = $this->_mandateId;
         }
+
+        $this->data['mandateId'] = $this->_mandateId;
+
         if (!empty($this->_amount)) {
-            $this->data['amount'] = (int)$this->_amount;
+            $this->data['amount'] = $this->_amount;
         }
         if (!empty($this->_description)) {
             $this->data['description'] = $this->_description;
         }
-        if (!empty($this->_processDate)) {
+        if ($this->_processDate instanceof \DateTime) {
             $this->data['processDate'] = $this->_processDate->format('d-m-Y');
         }
 
         return parent::getData();
     }
 
+    /**
+     * @inheritdoc
+     */
     public function doRequest($endpoint = null, $version = null)
     {
         return parent::doRequest('DirectDebit/mandateDebit');

--- a/src/Api/DirectDebit/MandateGet.php
+++ b/src/Api/DirectDebit/MandateGet.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 7-7-16
- * Time: 15:56
- */
 
 namespace Paynl\Api\DirectDebit;
-
 
 class MandateGet extends DirectDebit
 {
@@ -26,6 +19,9 @@ class MandateGet extends DirectDebit
         $this->_mandateId = $mandateId;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getData()
     {
         $this->data['mandateId'] = $this->_mandateId;
@@ -33,6 +29,9 @@ class MandateGet extends DirectDebit
         return parent::getData();
     }
 
+    /**
+     * @inheritdoc
+     */
     public function doRequest($endpoint = null, $version = null)
     {
         return parent::doRequest('DirectDebit/mandateGet');

--- a/src/Api/DirectDebit/RecurringAdd.php
+++ b/src/Api/DirectDebit/RecurringAdd.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 6-7-16
- * Time: 16:23
- */
 
 namespace Paynl\Api\DirectDebit;
-
 
 use Paynl\Error\Required;
 
@@ -17,6 +10,7 @@ class RecurringAdd extends MandateAdd
      * @var int Need for recurring part, if intervalValue is 2 and intervalPeriod is 1 than process the directdebit every two weeks
      */
     private $_intervalValue;
+
     /**
      * @var int 1 : Week, 2 : Month, 3: Quarter, 4 : Half year, 5: Year, 6: Day
      */
@@ -38,22 +32,29 @@ class RecurringAdd extends MandateAdd
         $this->_intervalPeriod = $intervalPeriod;
     }
 
+    /**
+     * @inheritdoc
+     * @throws Required intervalValue is required
+     * @throws Required intervalPeriod is required
+     */
     public function getData()
     {
         if(empty($this->_intervalValue)){
             throw new Required('intervalValue');
-        } else {
-            $this->data['intervalValue'] = $this->_intervalValue;
         }
         if(empty($this->_intervalPeriod)){
             throw new Required('intervalPeriod');
-        } else {
-            $this->data['intervalPeriod'] = $this->_intervalPeriod;
         }
+
+        $this->data['intervalValue'] = $this->_intervalValue;
+        $this->data['intervalPeriod'] = $this->_intervalPeriod;
 
         return parent::getData();
     }
 
+    /**
+     * @inheritdoc
+     */
     public function doRequest($endpoint = 'DirectDebit/recurringAdd', $version = null)
     {
         return parent::doRequest($endpoint, $version);

--- a/src/Api/DirectDebit/RecurringGet.php
+++ b/src/Api/DirectDebit/RecurringGet.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 7-7-16
- * Time: 15:51
- */
 
 namespace Paynl\Api\DirectDebit;
 
@@ -27,6 +21,10 @@ class RecurringGet extends DirectDebit
         $this->_mandateId = $mandateId;
     }
 
+    /**
+     * @inheritdoc
+     * @throws Required mandateId is required
+     */
     public function getData()
     {
         if(empty($this->_mandateId)){
@@ -38,6 +36,9 @@ class RecurringGet extends DirectDebit
         return parent::getData();
     }
 
+    /**
+     * @inheritdoc
+     */
     public function doRequest($endpoint = null, $version = null)
     {
         return parent::doRequest('DirectDebit/recurringGet');

--- a/src/Api/DirectDebit/Update.php
+++ b/src/Api/DirectDebit/Update.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 13-7-16
- * Time: 14:04
- */
 
 namespace Paynl\Api\DirectDebit;
-
 
 use Paynl\Error\Required;
 
@@ -36,7 +29,7 @@ class Update extends DirectDebit
      */
     private $_bankaccountBic;
     /**
-     * @var string Date on which the directdebit needs to be processed.
+     * @var \Datetime Date on which the directdebit needs to be processed.
      */
     private $_processDate;
     /**
@@ -137,7 +130,7 @@ class Update extends DirectDebit
      */
     public function setProcessDate(\DateTime $processDate)
     {
-        $this->_processDate = $processDate->format('d-m-Y');
+        $this->_processDate = $processDate;
     }
 
     /**
@@ -244,13 +237,18 @@ class Update extends DirectDebit
         $this->_extra3 = $extra3;
     }
 
+    /**
+     * @inheritdoc
+     * @throws Required mandateId is required
+     */
     protected function getData()
     {
         if(empty($this->_mandateId)){
             throw new Required('mandateId');
-        } else {
-            $this->data['mandateId'];
         }
+
+        $this->data['mandateId'];
+
         if(!empty($this->_amount)){
             $this->data['amount'] = $this->_amount;
         }
@@ -263,8 +261,8 @@ class Update extends DirectDebit
         if(!empty($this->_bankaccountBic)){
             $this->data['bankaccountBic'] = $this->_bankaccountBic;
         }
-        if(!empty($this->_processDate)){
-            $this->data['processDate'] = $this->_processDate;
+        if ($this->_processDate instanceof \DateTime) {
+            $this->data['processDate'] = $this->_processDate->format('d-m-Y');
         }
         if(!empty($this->_intervalValue)){
             $this->data['intervalValue'] = $this->_intervalValue;
@@ -308,6 +306,10 @@ class Update extends DirectDebit
 
         return parent::getData();
     }
+
+    /**
+     * @inheritdoc
+     */
     public function doRequest($endpoint = '', $version = null)
     {
         return parent::doRequest('DirectDebit/update');

--- a/src/Api/Instore/ConfirmPayment.php
+++ b/src/Api/Instore/ConfirmPayment.php
@@ -20,7 +20,6 @@ namespace Paynl\Api\Instore;
 
 use Paynl\Error;
 
-
 /**
  * Confirm the payment, and optionally sent the receipt to the enduser
  *
@@ -28,9 +27,6 @@ use Paynl\Error;
  */
 class ConfirmPayment extends Instore
 {
-    protected $apiTokenRequired = false;
-    protected $serviceIdRequired = false;
-
     /**
      * @var string The hash of the transaction
      */
@@ -39,6 +35,10 @@ class ConfirmPayment extends Instore
      * @var string The email address of the end-user
      */
     protected $emailAddress;
+    /**
+     * @var int The language of the email sent
+     */
+    protected $languageId;
 
     /**
      * @param string $hash
@@ -65,19 +65,15 @@ class ConfirmPayment extends Instore
     }
 
     /**
-     * @var int The language of the email sent
-     */
-    protected $languageId;
-
-    /**
-     * @return array The data
-     * @throws Error\Required
+     * @inheritdoc
+     * @throws Error\Required Hash is required
      */
     protected function getData()
     {
         if (empty($this->hash)) {
             throw new Error\Required('Hash is required');
         }
+
         $this->data['hash'] = $this->hash;
 
         if (!empty($this->emailAddress)) {
@@ -90,11 +86,8 @@ class ConfirmPayment extends Instore
         return parent::getData();
     }
 
-
     /**
-     * @param null $endpoint
-     * @param null $version
-     * @return array The result
+     * @inheritdoc
      */
     public function doRequest($endpoint = null, $version = null)
     {

--- a/src/Api/Instore/GetAllTerminals.php
+++ b/src/Api/Instore/GetAllTerminals.php
@@ -26,11 +26,9 @@ namespace Paynl\Api\Instore;
 class GetAllTerminals extends Instore
 {
     protected $apiTokenRequired = true;
-    protected $serviceIdRequired = false;
+
     /**
-     * @param null $endpoint
-     * @param null $version
-     * @return array the result
+     * @inheritdoc
      */
     public function doRequest($endpoint = null, $version = null)
     {

--- a/src/Api/Instore/GetTransactionTicket.php
+++ b/src/Api/Instore/GetTransactionTicket.php
@@ -27,26 +27,10 @@ use Paynl\Error;
  */
 class GetTransactionTicket extends Instore
 {
-    protected $apiTokenRequired = false;
-    protected $serviceIdRequired = false;
-
     /**
      * @var string The hash of the instore transaction
      */
     private $hash;
-
-    /**
-     * @return array the data
-     * @throws Error\Required
-     */
-    protected function getData()
-    {
-        if (empty($this->hash)) {
-            throw new Error\Required('Hash is niet geset');
-        }
-        $this->data['hash'] = $this->hash;
-        return parent::getData();
-    }
 
     /**
      * @param string $hash the hash of the instore transaction
@@ -57,9 +41,22 @@ class GetTransactionTicket extends Instore
     }
 
     /**
-     * @param null $endpoint
-     * @param null $version
-     * @return array the result
+     * @inheritdoc
+     * @throws Error\Required Hash is required
+     */
+    protected function getData()
+    {
+        if (empty($this->hash)) {
+            throw new Error\Required('Hash is required');
+        }
+
+        $this->data['hash'] = $this->hash;
+
+        return parent::getData();
+    }
+
+    /**
+     * @inheritdoc
      */
     public function doRequest($endpoint = null, $version = null)
     {

--- a/src/Api/Instore/Instore.php
+++ b/src/Api/Instore/Instore.php
@@ -19,7 +19,6 @@
 namespace Paynl\Api\Instore;
 
 use Paynl\Api\Api;
-use Paynl\Error;
 
 /**
  * Description of Instore
@@ -29,20 +28,7 @@ use Paynl\Error;
 class Instore extends Api
 {
     /**
-     * @var int the version of the api
+     * @inheritdoc
      */
     protected $version = 2;
-
-    /**
-     * @param string $endpoint
-     * @param int|null $version
-     * @return array The result
-     */
-    public function doRequest($endpoint, $version = null)
-    {
-        if (is_null($version)) {
-            $version = $this->version;
-        }
-        return parent::doRequest($endpoint, $version);
-    }
 }

--- a/src/Api/Instore/Payment.php
+++ b/src/Api/Instore/Payment.php
@@ -28,7 +28,6 @@ use Paynl\Error;
 class Payment extends Instore
 {
     protected $apiTokenRequired = true;
-    protected $serviceIdRequired = false;
 
     /**
      * @var string the TransactionId
@@ -39,24 +38,6 @@ class Payment extends Instore
      * @var string the terminalId
      */
     private $terminalId;
-
-    /**
-     * @return array The data
-     * @throws Error\Required
-     */
-    protected function getData()
-    {
-        if (empty($this->transactionId)) {
-            throw new Error\Required('transactionId is niet geset');
-        }
-        $this->data['transactionId'] = $this->transactionId;
-
-        if (!empty($this->terminalId)) {
-            $this->data['terminalId'] = $this->terminalId;
-        }
-
-        return parent::getData();
-    }
 
     /**
      * @param string $transactionId
@@ -75,9 +56,26 @@ class Payment extends Instore
     }
 
     /**
-     * @param null $endpoint
-     * @param null $version
-     * @return array The result
+     * @inheritdoc
+     * @throws Error\Required transactionId is required
+     */
+    protected function getData()
+    {
+        if (empty($this->transactionId)) {
+            throw new Error\Required('transactionId is required');
+        }
+
+        $this->data['transactionId'] = $this->transactionId;
+
+        if (!empty($this->terminalId)) {
+            $this->data['terminalId'] = $this->terminalId;
+        }
+
+        return parent::getData();
+    }
+
+    /**
+     * @inheritdoc
      */
     public function doRequest($endpoint = null, $version = null)
     {

--- a/src/Api/Instore/Status.php
+++ b/src/Api/Instore/Status.php
@@ -27,26 +27,10 @@ use Paynl\Error;
  */
 class Status extends Instore
 {
-    protected $apiTokenRequired = false;
-    protected $serviceIdRequired = false;
-
     /**
      * @var string The hash of the instore transaction
      */
     private $hash;
-
-    /**
-     * @return array the data
-     * @throws Error\Required
-     */
-    protected function getData()
-    {
-        if (empty($this->hash)) {
-            throw new Error\Required('Hash is niet geset');
-        }
-        $this->data['hash'] = $this->hash;
-        return parent::getData();
-    }
 
     /**
      * @param string $hash the hash of the instore transaction
@@ -57,9 +41,22 @@ class Status extends Instore
     }
 
     /**
-     * @param null $endpoint
-     * @param null $version
-     * @return array the result
+     * @inheritdoc
+     * @throws Error\Required Hash is required
+     */
+    protected function getData()
+    {
+        if (empty($this->hash)) {
+            throw new Error\Required('Hash is niet geset');
+        }
+
+        $this->data['hash'] = $this->hash;
+
+        return parent::getData();
+    }
+
+    /**
+     * @inheritdoc
      */
     public function doRequest($endpoint = null, $version = null)
     {

--- a/src/Api/Refund/Add.php
+++ b/src/Api/Refund/Add.php
@@ -20,7 +20,7 @@ namespace Paynl\Api\Refund;
 
 use Paynl\Helper;
 use Paynl\Config;
-use Paynl\Error\Required as ErrorRequired;
+use Paynl\Error\Required;
 
 /**
  * Api class to refund a transaction
@@ -89,35 +89,155 @@ class Add extends Refund
      */
     private $_currency;
     /**
-     * @var string the currency
+     * @var \Datetime the currency
      */
     private $_processDate;
+
+    /**
+     * @param int $amount
+     */
+    public function setAmount($amount)
+    {
+        $this->_amount = (int)$amount;
+    }
+
+    /**
+     * @param string $bankAccountHolder
+     */
+    public function setBankAccountHolder($bankAccountHolder)
+    {
+        $this->_bankAccountHolder = $bankAccountHolder;
+    }
+
+    /**
+     * @param string $bankAccountNumber
+     */
+    public function setBankAccountNumber($bankAccountNumber)
+    {
+        $this->_bankAccountNumber = $bankAccountNumber;
+    }
+
+    /**
+     * @param string $bankAccountBic
+     */
+    public function setBankAccountBic($bankAccountBic)
+    {
+        $this->_bankAccountBic = $bankAccountBic;
+    }
+
+    /**
+     * @param string $description
+     */
+    public function setDescription($description)
+    {
+        $this->_description = $description;
+    }
+
+    /**
+     * @param $promotorId
+     */
+    public function setPromotorId($promotorId)
+    {
+        $this->_promotorId = $promotorId;
+    }
+
+    /**
+     * @param $tool
+     */
+    public function setTool($tool)
+    {
+        $this->_tool = $tool;
+    }
+
+    /**
+     * @param $info
+     */
+    public function setInfo($info)
+    {
+        $this->_info = $info;
+    }
+
+    /**
+     * @param $object
+     */
+    public function setObject($object)
+    {
+        $this->_object = $object;
+    }
+
+    /**
+     * @param $extra1
+     */
+    public function setExtra1($extra1)
+    {
+        $this->_extra1 = $extra1;
+    }
+
+    /**
+     * @param $extra2
+     */
+    public function setExtra2($extra2)
+    {
+        $this->_extra2 = $extra2;
+    }
+
+    /**
+     * @param $extra3
+     */
+    public function setExtra3($extra3)
+    {
+        $this->_extra3 = $extra3;
+    }
+
+    /**
+     * @param $orderId
+     */
+    public function setOrderId($orderId)
+    {
+        $this->_orderId = $orderId;
+    }
+
+    /**
+     * @param $currency
+     */
+    public function setCurrency($currency)
+    {
+        $this->_currency = $currency;
+    }
+
+    /**
+     * @param \DateTime $processDate
+     */
+    public function setProcessDate(\DateTime $processDate)
+    {
+        $this->_processDate = $processDate;
+    }
 
     /**
      * Get data to send to the api
      *
      * @return array
-     * @throws ErrorRequired
+     * @throws Required serviceId via config
+     * @throws Required _amount Amount is not set
+     * @throws Required _bankAccountHolder bankAccountHolder is not set
+     * @throws Required _bankAccountNumber bankAccountNumber is not set
      */
     protected function getData()
     {
         Helper::requireServiceId();
+        if (empty($this->_amount)) {
+            throw new Required('Amount is not set', 1);
+        }
+        if (empty($this->_bankAccountHolder)) {
+            throw new Required('bankAccountHolder is not set', 1);
+        }
+        if (empty($this->_bankAccountNumber)) {
+            throw new Required('bankAccountNumber is not set', 1);
+        }
 
         $this->data['serviceId'] = Config::getServiceId();
-
-        if (empty($this->_amount)) {
-            throw new ErrorRequired('Amount is not set', 1);
-        }
         $this->data['amount'] = $this->_amount;
-
-        if (empty($this->_bankAccountHolder)) {
-            throw new ErrorRequired('bankAccountHolder is not set', 1);
-        }
         $this->data['bankAccountHolder'] = $this->_bankAccountHolder;
-
-        if (empty($this->_bankAccountNumber)) {
-            throw new ErrorRequired('bankAccountNumber is not set', 1);
-        }
         $this->data['bankAccountNumber'] = $this->_bankAccountNumber;
 
         if (!empty($this->_bankAccountBic)) {
@@ -153,7 +273,7 @@ class Add extends Refund
         if (isset($this->_currency)) {
             $this->data['currency'] = $this->_currency;
         }
-        if(!empty($this->_processDate)){
+        if($this->_processDate instanceof \Datetime){
             $this->data['processDate'] = $this->_processDate->format('d-m-Y');
         }
 
@@ -161,99 +281,7 @@ class Add extends Refund
     }
 
     /**
-     * @param int $amount
-     */
-    public function setAmount($amount)
-    {
-        $this->_amount = (int)$amount;
-    }
-
-    /**
-     * @param string $bankAccountHolder
-     */
-    public function setBankAccountHolder($bankAccountHolder)
-    {
-        $this->_bankAccountHolder = $bankAccountHolder;
-    }
-
-    /**
-     * @param string $bankAccountHolder
-     */
-    public function setBankAccountNumber($bankAccountNumber)
-    {
-        $this->_bankAccountNumber = $bankAccountNumber;
-    }
-
-    /**
-     * @param string $bankAccountHolder
-     */
-    public function setBankAccountBic($bankAccountBic)
-    {
-        $this->_bankAccountBic = $bankAccountBic;
-    }
-
-    /**
-     * @param string $description
-     */
-    public function setDescription($description)
-    {
-        $this->_description = $description;
-    }
-
-    public function setPromotorId($promotorId)
-    {
-        $this->_promotorId = $promotorId;
-    }
-
-    public function setTool($tool)
-    {
-        $this->_tool = $tool;
-    }
-
-    public function setInfo($info)
-    {
-        $this->_info = $info;
-    }
-
-    public function setObject($object)
-    {
-        $this->_object = $object;
-    }
-
-    public function setExtra1($extra1)
-    {
-        $this->_extra1 = $extra1;
-    }
-
-    public function setExtra2($extra2)
-    {
-        $this->_extra2 = $extra2;
-    }
-
-    public function setExtra3($extra3)
-    {
-        $this->_extra3 = $extra3;
-    }
-
-    public function setOrderId($orderId)
-    {
-        $this->_orderId = $orderId;
-    }
-
-    public function setCurrency($currency)
-    {
-        $this->_currency = $currency;
-    }
-
-    public function setProcessDate(\DateTime $processDate)
-    {
-        $this->_processDate = $processDate;
-    }
-
-    /**
-     * @param null $endpoint
-     * @param null $version
-     * @return array
+     * @inheritdoc
      */
     public function doRequest($endpoint = null, $version = null)
     {

--- a/src/Api/Refund/Refund.php
+++ b/src/Api/Refund/Refund.php
@@ -28,20 +28,7 @@ use Paynl\Api\Api;
 class Refund extends Api
 {
     /**
-     * @var int the version of the api
+     * @inheritdoc
      */
-    protected $_version = 2;
-
-    /**
-     * @param string $endpoint
-     * @param int|null $version
-     * @return array The result
-     */
-    public function doRequest($endpoint, $version = null)
-    {
-        if (is_null($version)) {
-            $version = $this->_version;
-        }
-        return parent::doRequest($endpoint, $version);
-    }
+    protected $version = 2;
 }

--- a/src/Api/Service/GetAll.php
+++ b/src/Api/Service/GetAll.php
@@ -3,11 +3,8 @@ namespace Paynl\Api\Service;
 
 class GetAll extends Service
 {
-
     /**
-     * @param null $endpoint
-     * @param null $version
-     * @return array
+     * @inheritdoc
      */
     public function doRequest($endpoint = null, $version = null)
     {

--- a/src/Api/Service/GetPayLinkUrl.php
+++ b/src/Api/Service/GetPayLinkUrl.php
@@ -6,15 +6,15 @@ class GetPayLinkUrl extends Service
     protected $serviceIdRequired = true;
 
     /**
-     * @var integer
+     * @var int
      */
     private $securityMode;
     /**
-     * @var integer
+     * @var int
      */
     private $amount;
     /**
-     * @var integer
+     * @var int
      */
     private $amountMin;
     /**
@@ -51,7 +51,7 @@ class GetPayLinkUrl extends Service
      */
     public function setSecurityMode($securityMode)
     {
-        $this->securityMode = $securityMode;
+        $this->securityMode = (int)$securityMode;
     }
 
     /**
@@ -126,6 +126,9 @@ class GetPayLinkUrl extends Service
         $this->info = $info;
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function getData()
     {
         $data = parent::getData();
@@ -133,20 +136,28 @@ class GetPayLinkUrl extends Service
         $data['securityMode'] = $this->securityMode;
         $data['amount'] = $this->amount;
         $data['amountMin'] = $this->amountMin;
-        if (isset($this->countryCode))
+
+        if (isset($this->countryCode)) {
             $data['countryCode'] = $this->countryCode;
-        if (isset($this->language))
+        }
+        if (isset($this->language)) {
             $data['language'] = $this->language;
-        if (isset($this->extra1))
+        }
+        if (isset($this->extra1)) {
             $data['extra1'] = $this->extra1;
-        if (isset($this->extra2))
+        }
+        if (isset($this->extra2)) {
             $data['extra2'] = $this->extra2;
-        if (isset($this->extra3))
+        }
+        if (isset($this->extra3)) {
             $data['extra3'] = $this->extra3;
-        if (isset($this->tool))
+        }
+        if (isset($this->tool)) {
             $data['tool'] = $this->tool;
-        if (isset($this->info))
+        }
+        if (isset($this->info)) {
             $data['info'] = $this->info;
+        }
 
         return $data;
     }

--- a/src/Api/Service/Service.php
+++ b/src/Api/Service/Service.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 16-1-17
- * Time: 20:26
- */
 
 namespace Paynl\Api\Service;
-
 
 use Paynl\Api\Api;
 
@@ -16,20 +9,7 @@ class Service extends Api
     protected $apiTokenRequired = true;
 
     /**
-     * @var int the version of the api
+     * @inheritdoc
      */
-    protected $_version = 3;
-
-    /**
-     * @param string $endpoint
-     * @param int|null $version
-     * @return array The result
-     */
-    public function doRequest($endpoint, $version = null)
-    {
-        if (is_null($version)) {
-            $version = $this->_version;
-        }
-        return parent::doRequest($endpoint, $version);
-    }
+    protected $version = 3;
 }

--- a/src/Api/Transaction/AddRecurring.php
+++ b/src/Api/Transaction/AddRecurring.php
@@ -28,21 +28,36 @@ use Paynl\Error;
 class AddRecurring extends Transaction
 {
     protected $apiTokenRequired = true;
-    protected $serviceIdRequired = false;
 
     /**
      * @var string
      */
     private $transactionId;
 
+    /**
+     * @var int the amount in cents
+     */
     private $amount;
+    /**
+     * @var string the description for this refund
+     */
     private $description;
+    /**
+     * @var string additional data extra1
+     */
     private $extra1;
+    /**
+     * @var string additional data extra2
+     */
     private $extra2;
+    /**
+     * @var string additional data extra3
+     */
     private $extra3;
 
     /**
      * @param mixed $amount
+     * @throws Error\Error
      */
     public function setAmount($amount)
     {
@@ -95,34 +110,20 @@ class AddRecurring extends Transaction
     }
 
     /**
-     * Do the request
-     *
-     * @param null $endpoint
-     * @param null $version
-     * @return array the result
-     */
-    public function doRequest($endpoint = null, $version = null)
-    {
-        return parent::doRequest('transaction/addRecurring');
-    }
-
-    /**
-     * Get data to send to the api
-     *
-     * @return array
-     * @throws Error\Required
+     * @inheritdoc
+     * @throws Error\Required TransactionId is niet geset
      */
     protected function getData()
     {
         if (empty($this->transactionId)) {
-            throw new Error\Required('TransactionId is niet geset');
+            throw new Error\Required('TransactionId is required');
         }
+
         $this->data['transactionId'] = $this->transactionId;
 
         if (isset($this->amount)) {
             $this->data['amount'] = $this->amount;
         }
-
         if (isset($this->description)) {
             $this->data['description'] = $this->description;
         }
@@ -137,5 +138,13 @@ class AddRecurring extends Transaction
         }
 
         return parent::getData();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function doRequest($endpoint = null, $version = null)
+    {
+        return parent::doRequest('transaction/addRecurring');
     }
 }

--- a/src/Api/Transaction/Approve.php
+++ b/src/Api/Transaction/Approve.php
@@ -19,6 +19,7 @@
 namespace Paynl\Api\Transaction;
 
 use Paynl\Error;
+
 /**
  * Description of Approve
  *
@@ -27,26 +28,11 @@ use Paynl\Error;
 class Approve extends Transaction
 {
     protected $apiTokenRequired = true;
-    protected $serviceIdRequired = false;
 
     /**
      * @var string
      */
     private $transactionId;
-
-    /**
-     * Get data to send to the api
-     *
-     * @return array
-     * @throws Error\Required
-     */
-    protected function getData() {
-        if(empty($this->transactionId)){
-            throw new Error\Required('TransactionId is niet geset');
-        }
-        $this->data['orderId'] = $this->transactionId;
-        return parent::getData();
-    }
 
     /**
      * Set the transactionId
@@ -58,11 +44,21 @@ class Approve extends Transaction
     }
 
     /**
-     * Do the request
-     *
-     * @param null $endpoint
-     * @param null $version
-     * @return array the result
+     * @inheritdoc
+     * @throws Error\Required TransactionId is required
+     */
+    protected function getData() {
+        if(empty($this->transactionId)){
+            throw new Error\Required('TransactionId is required');
+        }
+
+        $this->data['orderId'] = $this->transactionId;
+
+        return parent::getData();
+    }
+
+    /**
+     * @inheritdoc
      */
     public function doRequest($endpoint = null, $version = null) {
         return parent::doRequest('transaction/approve');

--- a/src/Api/Transaction/Capture.php
+++ b/src/Api/Transaction/Capture.php
@@ -19,6 +19,7 @@
 namespace Paynl\Api\Transaction;
 
 use Paynl\Error;
+
 /**
  * Description of Approve
  *
@@ -27,26 +28,11 @@ use Paynl\Error;
 class Capture extends Transaction
 {
     protected $apiTokenRequired = true;
-    protected $serviceIdRequired = false;
 
     /**
      * @var string
      */
     private $transactionId;
-
-    /**
-     * Get data to send to the api
-     *
-     * @return array
-     * @throws Error\Required
-     */
-    protected function getData() {
-        if(empty($this->transactionId)){
-            throw new Error\Required('TransactionId is niet geset');
-        }
-        $this->data['transactionId'] = $this->transactionId;
-        return parent::getData();
-    }
 
     /**
      * Set the transactionId
@@ -58,11 +44,21 @@ class Capture extends Transaction
     }
 
     /**
-     * Do the request
-     *
-     * @param null $endpoint
-     * @param null $version
-     * @return array the result
+     * @inheritdoc
+     * @throws Error\Required TransactionId is required
+     */
+    protected function getData() {
+        if(empty($this->transactionId)){
+            throw new Error\Required('TransactionId is niet geset');
+        }
+
+        $this->data['transactionId'] = $this->transactionId;
+
+        return parent::getData();
+    }
+
+    /**
+     * @inheritdoc
      */
     public function doRequest($endpoint = null, $version = null) {
         return parent::doRequest('transaction/capture');

--- a/src/Api/Transaction/Decline.php
+++ b/src/Api/Transaction/Decline.php
@@ -19,6 +19,7 @@
 namespace Paynl\Api\Transaction;
 
 use Paynl\Error;
+
 /**
  * Description of Approve
  *
@@ -27,26 +28,11 @@ use Paynl\Error;
 class Decline extends Transaction
 {
     protected $apiTokenRequired = true;
-    protected $serviceIdRequired = false;
 
     /**
      * @var string
      */
     private $transactionId;
-
-    /**
-     * Get data to send to the api
-     *
-     * @return array
-     * @throws Error\Required
-     */
-    protected function getData() {
-        if(empty($this->transactionId)){
-            throw new Error\Required('TransactionId is niet geset');
-        }
-        $this->data['orderId'] = $this->transactionId;
-        return parent::getData();
-    }
 
     /**
      * Set the transactionId
@@ -58,11 +44,21 @@ class Decline extends Transaction
     }
 
     /**
-     * Do the request
-     *
-     * @param null $endpoint
-     * @param null $version
-     * @return array the result
+     * @inheritdoc
+     * @throws Error\Required TransactionId is required
+     */
+    protected function getData() {
+        if(empty($this->transactionId)){
+            throw new Error\Required('TransactionId is niet geset');
+        }
+
+        $this->data['orderId'] = $this->transactionId;
+
+        return parent::getData();
+    }
+
+    /**
+     * @inheritdoc
      */
     public function doRequest($endpoint = null, $version = null) {
         return parent::doRequest('transaction/decline');

--- a/src/Api/Transaction/GetService.php
+++ b/src/Api/Transaction/GetService.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * Copyright (C) 2015 Andy Pieters <andy@andypieters.nl>
  *
@@ -35,13 +34,11 @@ class GetService extends Transaction
     /**
      * @var array cached result
      */
-    private static $cache = array();
+    private static $cache = [];
 
     /**
-     * Get data to send to the api
-     *
-     * @return array
-     * @throws \Paynl\Error\Required\ServiceId
+     * @inheritdoc
+     * @throws \Paynl\Error\Required\ServiceId serviceId is required
      */
     protected function getData()
     {
@@ -53,11 +50,7 @@ class GetService extends Transaction
     }
 
     /**
-     * Do the request
-     *
-     * @param null $endpoint
-     * @param null $version
-     * @return array The result
+     * @inheritdoc
      */
     public function doRequest($endpoint = null, $version = null)
     {
@@ -65,12 +58,10 @@ class GetService extends Transaction
             Helper::requireApiToken();
             Helper::requireServiceId();
             return self::$cache[Config::getServiceId()];
-        } else {
-            $result = parent::doRequest('transaction/getService');
-            self::$cache[Config::getServiceId()] = $result;
-            return $result;
         }
+
+        $result = parent::doRequest('transaction/getService');
+        self::$cache[Config::getServiceId()] = $result;
+        return $result;
     }
-
-
 }

--- a/src/Api/Transaction/Info.php
+++ b/src/Api/Transaction/Info.php
@@ -19,6 +19,7 @@
 namespace Paynl\Api\Transaction;
 
 use Paynl\Error;
+
 /**
  * Description of Info
  *
@@ -27,27 +28,11 @@ use Paynl\Error;
 class Info extends Transaction
 {
     protected $apiTokenRequired = true;
-    protected $serviceIdRequired = false;
 
     /**
      * @var string
      */
     private $transactionId;
-
-    /**
-     * Get data to send to the api
-     *
-     * @return array
-     * @throws Error\Required
-     */
-    protected function getData() {
-        if(empty($this->transactionId)){
-            throw new Error\Required('TransactionId is niet geset');
-        }
-        $this->data['transactionId'] = $this->transactionId;
-        return parent::getData();
-    }
-
     /**
      * Set the transactionId
      *
@@ -58,11 +43,21 @@ class Info extends Transaction
     }
 
     /**
-     * Do the request
-     *
-     * @param null $endpoint
-     * @param null $version
-     * @return array the result
+     * @inheritdoc
+     * @throws Error\Required TransactionId is required
+     */
+    protected function getData() {
+        if(empty($this->transactionId)){
+            throw new Error\Required('TransactionId required');
+        }
+
+        $this->data['transactionId'] = $this->transactionId;
+
+        return parent::getData();
+    }
+
+    /**
+     * @inheritdoc
      */
     public function doRequest($endpoint = null, $version = null) {
         return parent::doRequest('transaction/info');

--- a/src/Api/Transaction/Refund.php
+++ b/src/Api/Transaction/Refund.php
@@ -28,7 +28,6 @@ use Paynl\Error;
 class Refund extends Transaction
 {
     protected $apiTokenRequired = true;
-    protected $serviceIdRequired = false;
 
     /**
      * @var string the transactionId
@@ -47,34 +46,6 @@ class Refund extends Transaction
      * @var \DateTime the date the refund should take place
      */
     private $processDate;
-
-    /**
-     * Get data to send to the api
-     *
-     * @return array
-     * @throws Error\Required
-     */
-    protected function getData()
-    {
-        if (empty($this->transactionId)) {
-            throw new Error\Required('TransactionId is niet geset');
-        }
-        $this->data['transactionId'] = $this->transactionId;
-
-        if (!empty($this->amount)) {
-            $this->data['amount'] = $this->amount;
-        }
-
-	    if (!empty($this->description)) {
-		    $this->data['description'] = $this->description;
-	    }
-
-        if (!empty($this->processDate)) {
-            $this->data['processDate'] = $this->processDate->format('d-m-Y');
-        }
-
-        return parent::getData();
-    }
 
     /**
      * @param string $transactionId
@@ -109,9 +80,32 @@ class Refund extends Transaction
     }
 
     /**
-     * @param null $endpoint
-     * @param null $version
-     * @return array
+     * @inheritdoc
+     * @throws Error\Required TransactionId is required
+     */
+    protected function getData()
+    {
+        if (empty($this->transactionId)) {
+            throw new Error\Required('TransactionId is required');
+        }
+
+        $this->data['transactionId'] = $this->transactionId;
+
+        if (!empty($this->amount)) {
+            $this->data['amount'] = $this->amount;
+        }
+	    if (!empty($this->description)) {
+		    $this->data['description'] = $this->description;
+	    }
+        if ($this->processDate instanceof \DateTime) {
+            $this->data['processDate'] = $this->processDate->format('d-m-Y');
+        }
+
+        return parent::getData();
+    }
+
+    /**
+     * @inheritdoc
      */
     public function doRequest($endpoint = null, $version = null)
     {

--- a/src/Api/Transaction/Transaction.php
+++ b/src/Api/Transaction/Transaction.php
@@ -31,17 +31,4 @@ class Transaction extends Api
      * @var int the version of the api
      */
     protected $version = 6;
-
-    /**
-     * @param string $endpoint
-     * @param int|null $version
-     * @return array The result
-     */
-    public function doRequest($endpoint, $version = null)
-    {
-        if (is_null($version)) {
-            $version = $this->version;
-        }
-        return parent::doRequest($endpoint, $version);
-    }
 }

--- a/src/Api/Transaction/Void.php
+++ b/src/Api/Transaction/Void.php
@@ -19,6 +19,7 @@
 namespace Paynl\Api\Transaction;
 
 use Paynl\Error;
+
 /**
  * Description of Approve
  *
@@ -27,26 +28,11 @@ use Paynl\Error;
 class Void extends Transaction
 {
     protected $apiTokenRequired = true;
-    protected $serviceIdRequired = false;
 
     /**
      * @var string
      */
     private $transactionId;
-
-    /**
-     * Get data to send to the api
-     *
-     * @return array
-     * @throws Error\Required
-     */
-    protected function getData() {
-        if(empty($this->transactionId)){
-            throw new Error\Required('TransactionId is niet geset');
-        }
-        $this->data['transactionId'] = $this->transactionId;
-        return parent::getData();
-    }
 
     /**
      * Set the transactionId
@@ -58,11 +44,19 @@ class Void extends Transaction
     }
 
     /**
-     * Do the request
-     *
-     * @param null $endpoint
-     * @param null $version
-     * @return array the result
+     * @inheritdoc
+     * @throws Error\Required TransactionId is required
+     */
+    protected function getData() {
+        if(empty($this->transactionId)){
+            throw new Error\Required('TransactionId is required');
+        }
+        $this->data['transactionId'] = $this->transactionId;
+        return parent::getData();
+    }
+
+    /**
+     * @inheritdoc
      */
     public function doRequest($endpoint = null, $version = null) {
         return parent::doRequest('transaction/voidAuthorization');

--- a/src/Api/Validate/IsPayServerIp.php
+++ b/src/Api/Validate/IsPayServerIp.php
@@ -1,40 +1,44 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 21-12-2015
- * Time: 12:27
- */
 
 namespace Paynl\Api\Validate;
 
-use \Paynl\Error;
+use \Paynl\Error\Required;
 
 class IsPayServerIp extends Validate
 {
-    protected $apiTokenRequired = false;
-    protected $serviceIdRequired = false;
-
+    /**
+     * @inheritdoc
+     * @throws Required ipAddress is required
+     */
     protected function getData()
     {
-
         if (!isset($this->data['ipAddress'])) {
-            throw new Error\Required('ipAddress is required');
+            throw new Required('ipAddress is required');
         }
 
         return $this->data;
     }
 
+    /**
+     * @param $ipAddress
+     */
     public function setIpAddress($ipAddress)
     {
         $this->data['ipAddress'] = $ipAddress;
     }
 
+    /**
+     * @inheritdoc
+     * @return bool
+     */
     protected function processResult($result)
     {
         return (bool)$result->result;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function doRequest($endpoint = null, $version = null)
     {
         return parent::doRequest('validate/isPayServerIp');

--- a/src/Api/Validate/Validate.php
+++ b/src/Api/Validate/Validate.php
@@ -29,17 +29,4 @@ class Validate extends Api
      * @var int the version of the api
      */
     protected $version = 1;
-
-    /**
-     * @param string $endpoint
-     * @param int|null $version
-     * @return array The result
-     */
-    public function doRequest($endpoint, $version = null)
-    {
-        if (is_null($version)) {
-            $version = $this->version;
-        }
-        return parent::doRequest($endpoint, $version);
-    }
 }

--- a/src/Api/Voucher/Activate.php
+++ b/src/Api/Voucher/Activate.php
@@ -3,11 +3,10 @@
 namespace Paynl\Api\Voucher;
 
 use Paynl\Error\Error;
-use Paynl\Error\Required as ErrorRequired;
+use Paynl\Error\Required;
 
 class Activate extends Voucher
 {
-
     protected $apiTokenRequired = true;
     protected $serviceIdRequired = true;
 
@@ -61,42 +60,46 @@ class Activate extends Voucher
      */
     public function setAmount($amount)
     {
-        if(is_numeric($amount)){
-            $this->_amount = $amount;
-        }else{
+        if(!is_numeric($amount)) {
             throw new Error('Amount is niet numeriek', 1);
         }
+        $this->_amount = $amount;
     }
 
+    /**
+     * @inheritdoc
+     * @throws Required cardNumber is required
+     * @throws Required amount is required
+     * @throws Required posId is required
+     */
     protected function getData()
     {
+        if(empty($this->_cardNumber)){
+            throw new Required('cardNumber is required', 1);
+        }
+        if(empty($this->_amount)){
+            throw new Required('Amount is required', 1);
+        }
+        if(empty($this->_posId)){
+            throw new Required('posId is required', 1);
+        }
+
+        $data['cardNumber'] = $this->_cardNumber;
+        $data['amount'] = $this->_amount;
+        $data['posId'] = $this->_posId;
+
         if(!empty($this->_pincode)){
             $data['pincode'] = $this->_pincode;
         }
-        if(empty($this->_cardNumber)){
-            throw new ErrorRequired('cardNumber is niet geset', 1);
-        }else{
-            $data['cardNumber'] = $this->_cardNumber;
-        }
-
-        if(empty($this->_amount)){
-            throw new ErrorRequired('Amount is niet geset', 1);
-        }else{
-            $data['amount'] = $this->_amount;
-        }
-
-        if(empty($this->_posId)){
-            throw new ErrorRequired('posId is niet geset', 1);
-        }else{
-            $data['posId'] = $this->_posId;
-        }
-
 
         $this->data = array_merge($data, $this->data);
 
         return parent::getData();
     }
 
+    /**
+     * @inheritdoc
+     */
     public function doRequest($endpoint = null, $version = null)
     {
         return parent::doRequest('voucher/activate');

--- a/src/Api/Voucher/Balance.php
+++ b/src/Api/Voucher/Balance.php
@@ -2,13 +2,11 @@
 
 namespace Paynl\Api\Voucher;
 
-use Paynl\Error\Required as ErrorRequired;
+use Paynl\Error\Required;
 
 class Balance extends Voucher
 {
-
     protected $apiTokenRequired = true;
-    protected $serviceIdRequired = false;
 
     /**
      * @var string The voucher card number
@@ -35,15 +33,20 @@ class Balance extends Voucher
         $this->_pincode = $pincode;
     }
 
+    /**
+     * @inheritdoc
+     * @throws Required cardNumber is required
+     */
     protected function getData()
     {
+        if(empty($this->_cardNumber)){
+            throw new Required('cardNumber is required', 1);
+        }
+
+        $data['cardNumber'] = $this->_cardNumber;
+
         if(!empty($this->_pincode)){
             $data['pincode'] = $this->_pincode;
-        }
-        if(empty($this->_cardNumber)){
-            throw new ErrorRequired('cardNumber is niet geset', 1);
-        }else{
-            $data['cardNumber'] = $this->_cardNumber;
         }
 
         $this->data = array_merge($data, $this->data);
@@ -51,6 +54,9 @@ class Balance extends Voucher
         return parent::getData();
     }
 
+    /**
+     * @inheritdoc
+     */
     public function doRequest($endpoint = null, $version = null)
     {
         return parent::doRequest('voucher/balance');

--- a/src/Api/Voucher/Charge.php
+++ b/src/Api/Voucher/Charge.php
@@ -3,13 +3,11 @@
 namespace Paynl\Api\Voucher;
 
 use Paynl\Error\Error;
-use Paynl\Error\Required as ErrorRequired;
+use Paynl\Error\Required;
 
 class Charge extends Voucher
 {
-
     protected $apiTokenRequired = true;
-    protected $serviceIdRequired = false;
 
     /**
      * @var string The voucher card number
@@ -49,29 +47,31 @@ class Charge extends Voucher
      */
     public function setAmount($amount)
     {
-        if (is_numeric($amount)) {
-            $this->_amount = $amount;
-        } else {
+        if (!is_numeric($amount)) {
             throw new Error('Amount is niet numeriek', 1);
         }
+        $this->_amount = $amount;
     }
 
+    /**
+     * @inheritdoc
+     * @throws Required cardNumber is required
+     * @throws Required amount is required
+     */
     protected function getData()
     {
         if (empty($this->_cardNumber)) {
-            throw new ErrorRequired('cardNumber is niet geset', 1);
-        } else {
-            $data['cardNumber'] = $this->_cardNumber;
+            throw new Required('cardNumber is required', 1);
         }
+        if (empty($this->_amount)) {
+            throw new Required('amount is required', 1);
+        }
+
+        $data['amount'] = $this->_amount;
+        $data['cardNumber'] = $this->_cardNumber;
 
         if (!empty($this->_pincode)) {
             $data['pincode'] = $this->_pincode;
-        }
-
-        if (empty($this->_amount)) {
-            throw new ErrorRequired('Amount is niet geset', 1);
-        } else {
-            $data['amount'] = $this->_amount;
         }
 
         $this->data = array_merge($data, $this->data);
@@ -79,6 +79,9 @@ class Charge extends Voucher
         return parent::getData();
     }
 
+    /**
+     * @inheritdoc
+     */
     public function doRequest($endpoint = null, $version = null)
     {
         return parent::doRequest('voucher/charge');

--- a/src/Api/Voucher/Voucher.php
+++ b/src/Api/Voucher/Voucher.php
@@ -11,19 +11,4 @@ class Voucher extends Api
      * @var int the version of the api
      */
     protected $version = 1;
-
-    /**
-     * @param string $endpoint
-     * @param int|null $version
-     *
-     * @return array The result
-     */
-    public function doRequest($endpoint, $version = null)
-    {
-        if (is_null($version)) {
-            $version = $this->version;
-        }
-
-        return parent::doRequest($endpoint, $version);
-    }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 namespace Paynl;
 
 use Curl\Curl;
@@ -43,7 +42,7 @@ class Config
     /**
      * @var string path tho CAInfo location
      */
-    private static $CAInfoLocation = null;
+    private static $CAInfoLocation;
 
     /**
      * @var bool Disable this if you have certificate errors that you don't know how to fix
@@ -140,29 +139,29 @@ class Config
      */
     public static function setApiVersion($apiVersion)
     {
-        self::$apiVersion = $apiVersion;
+        self::$apiVersion = (int) $apiVersion;
     }
 
     /**
      * @param string $endpoint The endpoint of the API, for example Transaction/Start
-     * @param string|null $version
+     * @param int|null $version
      *
      * @return string The url to the api
      */
     public static function getApiUrl($endpoint, $version = null)
     {
-        if (is_null($version)) {
+        if ($version === null) {
             $version = self::$apiVersion;
         }
         return self::$apiBase . '/v' . $version . '/' . $endpoint . '/json';
     }
 
     /**
-     * @return object
+     * @return \Paynl\Curl\CurlInterface
      */
     public static function getCurl()
     {
-        if (null === self::$curl) {
+        if (self::$curl === null) {
             self::$curl = new Curl();
         }
 

--- a/src/Curl/CurlInterface.php
+++ b/src/Curl/CurlInterface.php
@@ -1,0 +1,53 @@
+<?php
+namespace Paynl\Curl;
+
+/**
+ * Interface CurlInterface
+ * This is the (current) Curl interface as taken from php-curl-class/php-curl-class.
+ * This is the interface currently used by the SDK
+ *
+ * @property string $error
+ * @property string $errorMessage
+ *
+ * @package Paynl\Curl
+ */
+interface CurlInterface
+{
+    /**
+     * Post
+     *
+     * @access public
+     * @param string $url
+     * @param array $data
+     * @param bool $follow_303_with_post If true, will cause 303 redirections to be followed using
+     *     a POST request (default: false).
+     *     Notes:
+     *       - Redirections are only followed if the CURLOPT_FOLLOWLOCATION option is set to true.
+     *       - According to the HTTP specs (see [1]), a 303 redirection should be followed using
+     *         the GET method. 301 and 302 must not.
+     *       - In order to force a 303 redirection to be performed using the same method, the
+     *         underlying cURL object must be set in a special state (the CURLOPT_CURSTOMREQUEST
+     *         option must be set to the method to use after the redirection). Due to a limitation
+     *         of the cURL extension of PHP < 5.5.11 ([2], [3]) and of HHVM, it is not possible
+     *         to reset this option. Using these PHP engines, it is therefore impossible to
+     *         restore this behavior on an existing php-curl-class Curl object.
+     *
+     * @return mixed
+     *
+     * [1] https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.2
+     * [2] https://github.com/php/php-src/pull/531
+     * [3] http://php.net/ChangeLog-5.php#5.5.11
+     */
+    public function post($url, array $data = [], $follow_303_with_post = false);
+
+    /**
+     * Set Opt
+     *
+     * @access public
+     * @param string $option
+     * @param mixed $value
+     *
+     * @return boolean
+     */
+    public function setOpt($option, $value);
+}

--- a/src/Curl/Dummy.php
+++ b/src/Curl/Dummy.php
@@ -1,28 +1,70 @@
 <?php
 namespace Paynl\Curl;
 
-class Dummy
+class Dummy implements CurlInterface
 {
+    /**
+     * @var string
+     */
     private $_result;
 
+    /**
+     * @var mixed
+     */
     public $error;
-    
+
+    /**
+     * @var string
+     */
+    public $errorMessage;
+
+    /**
+     * @param $result
+     */
     public function setResult($result){
         $this->_result = $result;
     }
 
-    //dummy function to prevent errors
+    /**
+     * Prevent possible other uses that might actually do something
+     *
+     * @param string $name
+     * @param mixed $arguments
+     * @return bool|mixed
+     */
     public function __call($name, $arguments)
     {
-        if(in_array($name, array(
+        if(in_array($name, [
             'delete',
             'get',
             'patch',
-            'post',
             'put',
-        ))){
+        ], true)){
             return json_decode($this->_result);
         }
         return true;
     }
+
+    /**
+     * This is just a dummy transport, thus return the pre-given results
+     *
+     * @see Dummy::setResult()
+     * @inheritdoc
+     */
+    public function post($url, array $data = [], $follow_303_with_post = false)
+    {
+        return json_decode($this->_result);
+    }
+
+    /**
+     * This is just a dummy transport, thus ignore
+     *
+     * @inheritdoc
+     */
+    public function setOpt($option, $value)
+    {
+        return true;
+    }
+
+
 }

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 6-7-16
- * Time: 17:59
- */
 
 namespace Paynl;
-
 
 use Paynl\Api\Currency as Api;
 use Paynl\Error\NotFound;
@@ -40,7 +33,7 @@ class Currency
         $allCurrencies = self::getAll();
 
         foreach($allCurrencies as $currency){
-            if(strtoupper($currency['abbreviation']) == strtoupper($isoCode)){
+            if(strcasecmp($currency['abbreviation'], $isoCode) === 0){
                 return $currency['id'];
             }
         }

--- a/src/DirectDebit.php
+++ b/src/DirectDebit.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 6-7-16
- * Time: 16:39
- */
 
 namespace Paynl;
-
 
 use Paynl\Api\DirectDebit as Api;
 use Paynl\Error\Required;
@@ -15,31 +8,31 @@ use Paynl\Result\DirectDebit as Result;
 
 class DirectDebit
 {
-    /**
-     * Add a Single DirectDebit Transaction (non recurring)
-     *
-     * @param array $options
-     * @throws Required When a required field is not set
-     */
-    public static function add($options = array())
-    {
-        $api = new Api\DebitAdd();
 
+    /**
+     * @param array $options
+     * @return Result\Add
+     * @throws Required amount is required
+     * @throws Required bankaccountHolder is required
+     * @throws Required bankaccountNumber is required
+     */
+    public static function add(array $options = [])
+    {
         if (empty($options['amount'])) {
             throw new Required('amount');
-        } else {
-            $api->setAmount(round($options['amount'] * 100));
         }
         if (empty($options['bankaccountHolder'])) {
             throw new Required('bankaccountHolder');
-        } else {
-            $api->setBankaccountHolder($options['bankaccountHolder']);
         }
         if (empty($options['bankaccountNumber'])) {
             throw new Required('bankaccountNumber');
-        } else {
-            $api->setBankaccountNumber($options['bankaccountNumber']);
         }
+
+        $api = new Api\DebitAdd();
+        $api->setAmount(round($options['amount'] * 100));
+        $api->setBankaccountHolder($options['bankaccountHolder']);
+        $api->setBankaccountNumber($options['bankaccountNumber']);
+
         if (!empty($options['bankaccountBic'])) {
             $api->setBankaccountBic($options['bankaccountBic']);
         }
@@ -85,7 +78,6 @@ class DirectDebit
         if (!empty($options['exchangeUrl'])) {
             $api->setExchangeUrl($options['exchangeUrl']);
         }
-
         $result = $api->doRequest();
 
         return new Result\Add($result);
@@ -105,8 +97,7 @@ class DirectDebit
         $api = new Api\Delete();
         $api->setMandateId($mandateId);
 
-        $result = $api->doRequest();
-        return $result;
+        return $api->doRequest();
     }
 
     public function update($mandateId, $options)
@@ -114,6 +105,7 @@ class DirectDebit
         if (empty($mandateId)) {
             throw new Required('mandateId');
         }
+
         $api = new Api\Update();
         $api->setMandateId($mandateId);
 
@@ -175,7 +167,6 @@ class DirectDebit
         if (!empty($options['extra3'])) {
             $api->setExtra3($options['extra3']);
         }
-        $result = $api->doRequest();
-        return $result;
+        return $api->doRequest();
     }
 }

--- a/src/DirectDebit/Mandate.php
+++ b/src/DirectDebit/Mandate.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 7-7-16
- * Time: 11:37
- */
 
 namespace Paynl\DirectDebit;
 
@@ -15,23 +9,21 @@ use Paynl\Result\DirectDebit\Mandate as Result;
 class Mandate
 {
     public static function add($options){
-        $api = new Api\MandateAdd();
-
         if (empty($options['amount'])) {
             throw new Required('amount');
-        } else {
-            $api->setAmount(round($options['amount'] * 100));
         }
         if (empty($options['bankaccountHolder'])) {
             throw new Required('bankaccountHolder');
-        } else {
-            $api->setBankaccountHolder($options['bankaccountHolder']);
         }
         if (empty($options['bankaccountNumber'])) {
             throw new Required('bankaccountNumber');
-        } else {
-            $api->setBankaccountNumber($options['bankaccountNumber']);
         }
+
+        $api = new Api\MandateAdd();
+        $api->setAmount(round($options['amount'] * 100));
+        $api->setBankaccountHolder($options['bankaccountHolder']);
+        $api->setBankaccountNumber($options['bankaccountNumber']);
+
         if (!empty($options['bankaccountBic'])) {
             $api->setBankaccountBic($options['bankaccountBic']);
         }
@@ -80,19 +72,18 @@ class Mandate
         if(!empty($options['intervalQuantity'])){
             $api->setIntervalQuantity((int)$options['intervalQuantity']);
         }
-
         $result = $api->doRequest();
+
         return new Result\Add($result);
     }
 
     public static function addTransaction($options){
-        $api = new Api\MandateDebit();
-
         if(empty($options['mandateId'])){
             throw new Required('mandateId');
-        } else {
-            $api->setMandateId($options['mandateId']);
         }
+
+        $api = new Api\MandateDebit();
+        $api->setMandateId($options['mandateId']);
 
         if(!empty($options['amount'])){
             $api->setAmount($options['amount']);
@@ -107,6 +98,7 @@ class Mandate
             $api->setProcessDate($options['processDate']);
         }
         $result = $api->doRequest();
+
         return new Result\AddTransaction($result);
 
     }

--- a/src/DirectDebit/Recurring.php
+++ b/src/DirectDebit/Recurring.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 7-7-16
- * Time: 12:02
- */
 
 namespace Paynl\DirectDebit;
 
@@ -23,23 +17,21 @@ class Recurring
 
     public static function add($options)
     {
-        $api = new Api\RecurringAdd();
-
         if (empty($options['amount'])) {
             throw new Required('amount');
-        } else {
-            $api->setAmount(round($options['amount'] * 100));
         }
         if (empty($options['bankaccountHolder'])) {
             throw new Required('bankaccountHolder');
-        } else {
-            $api->setBankaccountHolder($options['bankaccountHolder']);
         }
         if (empty($options['bankaccountNumber'])) {
             throw new Required('bankaccountNumber');
-        } else {
-            $api->setBankaccountNumber($options['bankaccountNumber']);
         }
+
+        $api = new Api\RecurringAdd();
+        $api->setAmount(round($options['amount'] * 100));
+        $api->setBankaccountHolder($options['bankaccountHolder']);
+        $api->setBankaccountNumber($options['bankaccountNumber']);
+
         if (!empty($options['bankaccountBic'])) {
             $api->setBankaccountBic($options['bankaccountBic']);
         }
@@ -94,8 +86,8 @@ class Recurring
         if (!empty($options['intervalPeriod'])) {
             $api->setIntervalPeriod((int)$options['intervalPeriod']);
         }
-
         $result = $api->doRequest();
+
         return new Result\Add($result);
     }
 

--- a/src/Error/Api.php
+++ b/src/Error/Api.php
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 namespace Paynl\Error;
 
 /**

--- a/src/Error/Error.php
+++ b/src/Error/Error.php
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 namespace Paynl\Error;
 
 /**

--- a/src/Error/NotFound.php
+++ b/src/Error/NotFound.php
@@ -1,18 +1,11 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 6-7-16
- * Time: 18:06
- */
 
 namespace Paynl\Error;
-
 
 class NotFound extends Error
 {
 
-    public function __construct($objectName, $identifier, Exception $previous = null)
+    public function __construct($objectName, $identifier, \Exception $previous = null)
     {
         $message = "$objectName: '$identifier' Not found";
         parent::__construct($message, 404, $previous);

--- a/src/Error/Required.php
+++ b/src/Error/Required.php
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 namespace Paynl\Error;
 
 /**

--- a/src/Error/Required/ApiToken.php
+++ b/src/Error/Required/ApiToken.php
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 namespace Paynl\Error\Required;
 
 use \Paynl\Error\Required;

--- a/src/Error/Required/ServiceId.php
+++ b/src/Error/Required/ServiceId.php
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 namespace Paynl\Error\Required;
 
 use \Paynl\Error\Required;

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -18,7 +18,6 @@
 
 namespace Paynl;
 
-
 use Paynl\Error;
 
 /**
@@ -62,26 +61,22 @@ class Helper
      */
     public static function getIp()
     {
-        //Just get the headers if we can or else use the SERVER global
+        // Use $_SERVER or get the headers if we can
+        $headers = $_SERVER;
         if (function_exists('apache_request_headers')) {
             $headers = apache_request_headers();
-        } else {
-            $headers = $_SERVER;
         }
-        //Get the forwarded IP if it exists
+
+        // Get the forwarded IP if it exists
+        $the_ip = $_SERVER['REMOTE_ADDR'];
         if (array_key_exists('X-Forwarded-For', $headers)) {
             $the_ip = $headers['X-Forwarded-For'];
         } elseif (array_key_exists('HTTP_X_FORWARDED_FOR', $headers)) {
             $the_ip = $headers['HTTP_X_FORWARDED_FOR'];
-        } else {
-            $the_ip = $_SERVER['REMOTE_ADDR'];
         }
         $arrIp = explode(',', $the_ip);
-        $the_ip = $arrIp[0];
 
-        $the_ip = filter_var(trim($the_ip), FILTER_VALIDATE_IP);
-
-        return $the_ip;
+        return filter_var(trim($arrIp[0]), FILTER_VALIDATE_IP);
     }
 
     /**
@@ -104,9 +99,9 @@ class Helper
     private static function nearest($number, $numbers)
     {
         $output = FALSE;
-        $number = intval($number);
+        $number = (int) $number;
         if (is_array($numbers) && count($numbers) >= 1) {
-            $NDat = array();
+            $NDat = [];
             foreach ($numbers as $n) {
                 $NDat[abs($number - $n)] = $n;
             }
@@ -120,7 +115,7 @@ class Helper
     /**
      * Convert a stdClass object to an array
      *
-     * @param \stdClass $d
+     * @param \stdClass|array $d
      * @return array
      */
     public static function objectToArray($d)
@@ -128,22 +123,25 @@ class Helper
         if (is_object($d)) {
             $d = get_object_vars($d);
         }
-        if (is_array($d)) {
-            return array_map(array(__CLASS__, __FUNCTION__), $d); // recursive
-        } else {
+        if (!is_array($d)) {
             return $d;
         }
+        return array_map([__CLASS__, __FUNCTION__], $d); // recursive
     }
 
+    /**
+     * @param int|float $amountInclTax
+     * @param int|float $taxAmount
+     * @return float|int
+     */
     public static function calculateTaxPercentage($amountInclTax, $taxAmount){
         // return 0 if amount or tax is 0
         if ($taxAmount == 0 || $amountInclTax == 0) {
             return 0;
         }
         $amountExclTax = $amountInclTax - $taxAmount;
-        $taxRate = ($taxAmount / $amountExclTax) * 100;
 
-        return $taxRate;
+        return ($taxAmount / $amountExclTax) * 100;
     }
     /**
      * Determine the tax class to send to Pay.nl
@@ -154,16 +152,16 @@ class Helper
      */
     public static function calculateTaxClass($amountInclTax, $taxAmount)
     {
-        $taxClasses = array(
+        $taxClasses = [
             0 => 'N',
             6 => 'L',
             21 => 'H'
-        );
+        ];
 
         $taxRate = self::calculateTaxPercentage($amountInclTax, $taxAmount);
 
         $nearestTaxRate = self::nearest($taxRate, array_keys($taxClasses));
-        return ($taxClasses[$nearestTaxRate]);
+        return $taxClasses[$nearestTaxRate];
     }
 
     /**
@@ -177,7 +175,7 @@ class Helper
     {
         $strAddress = trim($strAddress);
 
-        $a = preg_split('/(\\s+)([0-9]+)/', $strAddress, 2,
+        $a = preg_split('/(\\s+)(\d+)/', $strAddress, 2,
             PREG_SPLIT_DELIM_CAPTURE);
         $strStreetName = trim(array_shift($a));
         $strStreetNumber = trim(implode('', $a));
@@ -190,7 +188,7 @@ class Helper
             $strStreetName = implode('', $a);
         }
 
-        return array($strStreetName, $strStreetNumber);
+        return [$strStreetName, $strStreetNumber];
     }
 
     /**
@@ -201,13 +199,10 @@ class Helper
      */
     public static function getBaseUrl()
     {
-        $protocol = isset($_SERVER["HTTPS"]) ? 'https' : 'http';
+        $protocol = isset($_SERVER['HTTPS']) ? 'https' : 'http';
         $url = $protocol . '://' . $_SERVER['SERVER_NAME'] .':'.$_SERVER['SERVER_PORT']. $_SERVER['REQUEST_URI'];
 
-
-        // op de laatste / afknippen (index.php willen we niet zien)
-        $baseUrl = substr($url, 0, strrpos($url, '/'));
-
-        return $baseUrl;
+        // cut at last '/' (we dont want to see index.php)
+        return substr($url, 0, strrpos($url, '/'));
     }
 }

--- a/src/Refund.php
+++ b/src/Refund.php
@@ -33,34 +33,29 @@ class Refund
     /**
      * Start a new transaction
      *
-     * @param array|null $options
+     * @param array $options
      * @return Result\Add
      * @throws Error\Error
      */
-    public static function add($options = array())
+    public static function add(array $options = [])
     {
         $api = new Api\Add();
 
         if (isset($options['amount'])) {
             $api->setAmount(round($options['amount'] * 100));
         }
-
         if (isset($options['bankAccountHolder']) && !empty($options['bankAccountHolder'])) {
             $api->setBankAccountHolder($options['bankAccountHolder']);
         }
-
         if (isset($options['bankAccountNumber']) && !empty($options['bankAccountNumber'])) {
             $api->setBankAccountNumber($options['bankAccountNumber']);
         }
-
         if (isset($options['bankAccountBic']) && !empty($options['bankAccountBic'])) {
             $api->setBankAccountBic($options['bankAccountBic']);
         }
-
         if (isset($options['description']) && !empty($options['description'])) {
             $api->setDescription($options['description']);
         }
-
         if (isset($options['promotorId'])) {
             $api->setPromotorId($options['promotorId']);
         }

--- a/src/Result/DirectDebit/Add.php
+++ b/src/Result/DirectDebit/Add.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 6-7-16
- * Time: 18:22
- */
 
 namespace Paynl\Result\DirectDebit;
-
 
 use Paynl\Result\Result;
 

--- a/src/Result/DirectDebit/Get.php
+++ b/src/Result/DirectDebit/Get.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 6-7-16
- * Time: 18:22
- */
 
 namespace Paynl\Result\DirectDebit;
-
 
 use Paynl\Result\Result;
 

--- a/src/Result/DirectDebit/Mandate/Add.php
+++ b/src/Result/DirectDebit/Mandate/Add.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 6-7-16
- * Time: 18:22
- */
 
 namespace Paynl\Result\DirectDebit\Mandate;
-
 
 use Paynl\Result\Result;
 

--- a/src/Result/DirectDebit/Mandate/AddTransaction.php
+++ b/src/Result/DirectDebit/Mandate/AddTransaction.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 7-7-16
- * Time: 16:45
- */
 
 namespace Paynl\Result\DirectDebit\Mandate;
-
 
 use Paynl\Result\Result;
 

--- a/src/Result/DirectDebit/Mandate/Get.php
+++ b/src/Result/DirectDebit/Mandate/Get.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 6-7-16
- * Time: 18:22
- */
 
 namespace Paynl\Result\DirectDebit\Mandate;
-
 
 use Paynl\Result\Result;
 

--- a/src/Result/DirectDebit/Recurring/Add.php
+++ b/src/Result/DirectDebit/Recurring/Add.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 6-7-16
- * Time: 18:22
- */
 
 namespace Paynl\Result\DirectDebit\Recurring;
-
 
 use Paynl\Result\Result;
 

--- a/src/Result/DirectDebit/Recurring/Get.php
+++ b/src/Result/DirectDebit/Recurring/Get.php
@@ -1,13 +1,6 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 6-7-16
- * Time: 18:22
- */
 
 namespace Paynl\Result\DirectDebit\Recurring;
-
 
 use Paynl\Result\Result;
 

--- a/src/Result/Refund/Add.php
+++ b/src/Result/Refund/Add.php
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 namespace Paynl\Result\Refund;
 
 use Paynl\Result\Result;

--- a/src/Result/Result.php
+++ b/src/Result/Result.php
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 namespace Paynl\Result;
 
 /**
@@ -26,7 +25,7 @@ namespace Paynl\Result;
  */
 class Result
 {
-    protected $data = array();
+    protected $data = [];
 
     public function __construct($data)
     {

--- a/src/Result/Transaction/Start.php
+++ b/src/Result/Transaction/Start.php
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 namespace Paynl\Result\Transaction;
 
 use Paynl\Result\Result;

--- a/src/Result/Transaction/Transaction.php
+++ b/src/Result/Transaction/Transaction.php
@@ -33,7 +33,7 @@ class Transaction extends Result
      */
     public function isPaid()
     {
-        return $this->data['paymentDetails']['stateName'] == 'PAID';
+        return $this->data['paymentDetails']['stateName'] === 'PAID';
     }
 
     /**
@@ -41,7 +41,7 @@ class Transaction extends Result
      */
     public function isPending()
     {
-        return $this->data['paymentDetails']['stateName'] == 'PENDING' || $this->data['paymentDetails']['stateName'] == 'VERIFY';
+        return $this->data['paymentDetails']['stateName'] === 'PENDING' || $this->data['paymentDetails']['stateName'] === 'VERIFY';
     }
 
     /**
@@ -71,12 +71,14 @@ class Transaction extends Result
         if(!$this->isAuthorized()){
             throw new Error('Cannod void transaction, status is not authorized');
         }
+
         return \Paynl\Transaction::void($this->getId());
     }
     public function capture(){
         if(!$this->isAuthorized()){
             throw new Error('Cannod capture transaction, status is not authorized');
         }
+
         return \Paynl\Transaction::capture($this->getId());
     }
 
@@ -87,11 +89,11 @@ class Transaction extends Result
      */
     public function isRefunded($allowPartialRefunds = true)
     {
-        if ($this->data['paymentDetails']['stateName'] == 'REFUND') {
+        if ($this->data['paymentDetails']['stateName'] === 'REFUND') {
             return true;
         }
 
-        if ($allowPartialRefunds && $this->data['paymentDetails']['stateName'] == 'PARTIAL_REFUND') {
+        if ($allowPartialRefunds && $this->data['paymentDetails']['stateName'] === 'PARTIAL_REFUND') {
             return true;
         }
 
@@ -103,7 +105,7 @@ class Transaction extends Result
      */
     public function isPartiallyRefunded()
     {
-        return $this->data['paymentDetails']['stateName'] == 'PARTIAL_REFUND';
+        return $this->data['paymentDetails']['stateName'] === 'PARTIAL_REFUND';
     }
 
     /**
@@ -196,13 +198,13 @@ class Transaction extends Result
 
     public function approve()
     {
-        if ($this->isBeingVerified()) {
-            $result = \Paynl\Transaction::approve($this->getId());
-            $this->_reload(); //status is changed, so refresh the object
-            return $result;
-        } else {
+        if (!$this->isBeingVerified()) {
             throw new Error("Cannot approve transaction because it does not have the status 'verify'");
         }
+
+        $result = \Paynl\Transaction::approve($this->getId());
+        $this->_reload(); //status is changed, so refresh the object
+        return $result;
     }
 
     /**
@@ -210,7 +212,7 @@ class Transaction extends Result
      */
     public function isBeingVerified()
     {
-        return $this->data['paymentDetails']['stateName'] == 'VERIFY';
+        return $this->data['paymentDetails']['stateName'] === 'VERIFY';
     }
 
     /**
@@ -229,13 +231,13 @@ class Transaction extends Result
 
     public function decline()
     {
-        if ($this->isBeingVerified()) {
-            $result = \Paynl\Transaction::decline($this->getId());
-            $this->_reload();//status is changed, so refresh the object
-            return $result;
-        } else {
+        if (!$this->isBeingVerified()) {
             throw new Error("Cannot decline transaction because it does not have the status 'verify'");
         }
+
+        $result = \Paynl\Transaction::decline($this->getId());
+        $this->_reload();//status is changed, so refresh the object
+        return $result;
     }
 
 }

--- a/src/Result/Voucher/Voucher.php
+++ b/src/Result/Voucher/Voucher.php
@@ -41,8 +41,11 @@ class Voucher extends Result
      */
     public function charge($amount, $pin)
     {
-        $state = \Paynl\Voucher::charge(['cardNumber' => $this->getCardNumber(), 'amount' => $amount, 'pincode' => $pin]);
-
+        $state = \Paynl\Voucher::charge([
+          'cardNumber' => $this->getCardNumber(),
+          'amount' => $amount,
+          'pincode' => $pin
+        ]);
         $this->_reload();
         return $state;
     }

--- a/src/Service.php
+++ b/src/Service.php
@@ -17,34 +17,34 @@
  */
 
 namespace Paynl;
+
 use Paynl\Api\Service\GetAll;
 use Paynl\Api\Service\GetPayLinkUrl;
 
-
-/**
- * Description of Paymentmethods
- *
- * @author Andy Pieters <andy@andypieters.nl>
- */
 class Service
 {
-    public static function getPayLinkUrl($options = [])
+    /**
+     * @param array $options
+     * @return mixed
+     * @throws \Paynl\Error\Required securityMode is required
+     * @throws \Paynl\Error\Required amount is required
+     * @throws \Paynl\Error\Required amountMin is required
+     */
+    public static function getPayLinkUrl(array $options = [])
     {
-        $api = new GetPayLinkUrl();
-
         if (!isset($options['securityMode'])){
            throw new Error\Required('securityMode');
         }
-        $api->setSecurityMode($options['securityMode']);
-
         if(!isset($options['amount'])){
             throw new Error\Required('amount');
         }
-        $api->setAmount(round($options['amount']*100));
-
         if(!isset($options['amountMin'])){
             throw new Error\Required('amountMin');
         }
+
+        $api = new GetPayLinkUrl();
+        $api->setSecurityMode($options['securityMode']);
+        $api->setAmount(round($options['amount']*100));
         $api->setAmountMin(round($options['amountMin']*100));
 
         if(isset($options['countryCode'])){
@@ -69,8 +69,13 @@ class Service
             $api->setInfo($options['info']);
         }
         $result = $api->doRequest();
+
         return $result['url'];
     }
+
+    /**
+     * @return array
+     */
     public static function getAll(){
         $api = new GetAll();
         $result = $api->doRequest();

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -36,11 +36,11 @@ class Transaction
     /**
      * Start a new transaction
      *
-     * @param array|null $options
+     * @param array $options
      * @return Result\Start
      * @throws Error\Error
      */
-    public static function start($options = array())
+    public static function start(array $options = [])
     {
         $api = new Api\Start();
 
@@ -60,26 +60,21 @@ class Transaction
         if (isset($options['returnUrl'])) {
             $api->setFinishUrl($options['returnUrl']);
         }
-
         if (isset($options['exchangeUrl'])) {
             $api->setExchangeUrl($options['exchangeUrl']);
         }
-
         if (isset($options['paymentMethod']) && !empty($options['paymentMethod'])) {
             $api->setPaymentOptionId($options['paymentMethod']);
         }
         if (isset($options['bank']) && !empty($options['bank'])) {
             $api->setPaymentOptionSubId($options['bank']);
         }
-
         if (isset($options['description']) && !empty($options['description'])) {
             $api->setDescription($options['description']);
         }
-
         if (isset($options['testmode']) && $options['testmode'] == 1) {
             $api->setTestMode(true);
         }
-
         if (isset($options['extra1'])) {
             $api->setExtra1($options['extra1']);
         }
@@ -89,18 +84,15 @@ class Transaction
         if (isset($options['extra3'])) {
             $api->setExtra3($options['extra3']);
         }
-
         if (isset($options['ipaddress'])) {
             $api->setIpAddress($options['ipaddress']);
         }
-
         if (isset($options['invoiceDate'])) {
             if (is_string($options['invoiceDate'])) {
                 $options['invoiceDate'] = new \DateTime($options['invoiceDate']);
             }
             $api->setInvoiceDate($options['invoiceDate']);
         }
-
         if (isset($options['deliveryDate'])) {
             if (is_string($options['deliveryDate'])) {
                 $options['deliveryDate'] = new \DateTime($options['deliveryDate']);
@@ -109,19 +101,16 @@ class Transaction
         }
 
         if (isset($options['products'])) {
-            foreach ($options['products'] as $product) {
+            foreach ((array)$options['products'] as $product) {
+                $taxClass = 'N';
                 if (isset($product['tax'])) {
                     $taxClass = Helper::calculateTaxClass($product['price'], $product['tax']);
-                } else {
-                    $taxClass = 'N';
                 }
 
-                $taxPercentage = null;
+                $taxPercentage = round(Helper::calculateTaxPercentage($product['price'], $product['tax']));
                 if (isset($product['vatPercentage']) && is_numeric($product['vatPercentage'])) {
                     $taxPercentage = round($product['vatPercentage'], 2);
                     $taxClass = Helper::calculateTaxClass(100 + $taxPercentage, $taxPercentage);
-                } else {
-                    $taxPercentage = round(Helper::calculateTaxPercentage($product['price'], $product['tax']));
                 }
 
                 if (!isset($product['type'])) {
@@ -132,7 +121,7 @@ class Transaction
                     $product['qty'], $taxClass, $taxPercentage);
             }
         }
-        $enduser = array();
+        $enduser = [];
         if (isset($options['enduser'])) {
             if (isset($options['enduser']['birthDate']) && is_string($options['enduser']['birthDate'])) {
                 $options['enduser']['birthDate'] = new \DateTime($options['enduser']['birthDate']);
@@ -146,7 +135,7 @@ class Transaction
             $enduser['language'] = $options['language'];
         }
         if (isset($options['address'])) {
-            $address = array();
+            $address = [];
             if (isset($options['address']['streetName'])) {
                 $address['streetName'] = $options['address']['streetName'];
             }
@@ -168,7 +157,7 @@ class Transaction
             $enduser['address'] = $address;
         }
         if (isset($options['invoiceAddress'])) {
-            $invoiceAddress = array();
+            $invoiceAddress = [];
 
             if (isset($options['invoiceAddress']['initials'])) {
                 $invoiceAddress['initials'] = $options['invoiceAddress']['initials'];
@@ -217,13 +206,9 @@ class Transaction
         if (!empty($options['promotorId'])) {
             $api->setPromotorId($options['promotorId']);
         }
-
-
-
         if (isset($options['transferType'])) {
             $api->setTransferType($options['transferType']);
         }
-
         if (isset($options['transferValue'])) {
             $api->setTransferValue($options['transferValue']);
         }
@@ -237,25 +222,25 @@ class Transaction
      * Get the transaction in a return script.
      * This will automatically load orderId from the get string to fetch the transaction
      *
-     * @return \Paynl\Result\Transaction\Transaction
+     * @return Result\Transaction
      */
     public static function getForReturn()
     {
-        $transactionId = $_GET['orderId'];
-        return self::get($transactionId);
+        return self::get($_GET['orderId']);
     }
 
     /**
      * Get the transaction
      *
      * @param string $transactionId
-     * @return \Paynl\Result\Transaction\Transaction
+     * @return Result\Transaction
      */
     public static function get($transactionId)
     {
         $api = new Api\Info();
         $api->setTransactionId($transactionId);
         $result = $api->doRequest();
+
         $result['transactionId'] = $transactionId;
         return new Result\Transaction($result);
     }
@@ -264,23 +249,20 @@ class Transaction
      * Get the transaction in an exchange script.
      * This will work for all kinds of exchange calls (GET, POST AND POST_XML)
      *
-     * @return \Paynl\Result\Transaction\Transaction
+     * @return Result\Transaction
      */
     public static function getForExchange()
     {
         if (isset($_GET['order_id'])) {
-            $transactionId = $_GET['order_id'];
-        } elseif (isset($_POST['order_id'])) {
-            $transactionId = $_POST['order_id'];
-        } else {
-            // maybe its xml
-            $input = file_get_contents('php://input');
-            $xml = simplexml_load_string($input);
-
-            $transactionId = $xml->order_id;
+            return self::get($_GET['order_id']);
         }
-
-        return self::get($transactionId);
+        if (isset($_POST['order_id'])) {
+            return self::get($_POST['order_id']);
+        }
+        // maybe its xml
+        $input = file_get_contents('php://input');
+        $xml = simplexml_load_string($input);
+        return self::get($xml->order_id);
     }
 
     /**
@@ -299,16 +281,14 @@ class Transaction
     {
         $api = new Api\Refund();
         $api->setTransactionId($transactionId);
-        if (!is_null($amount)) {
+        if ($amount !== null) {
             $amount = round($amount * 100);
             $api->setAmount($amount);
         }
-
-        if (!is_null($description)) {
+        if ($description !== null) {
             $api->setDescription($description);
         }
-
-        if (!is_null($processDate)) {
+        if ($processDate !== null) {
             $api->setProcessDate($processDate);
         }
         $result = $api->doRequest();
@@ -321,6 +301,7 @@ class Transaction
         $api = new Api\Approve();
         $api->setTransactionId($transactionId);
         $result = $api->doRequest();
+
         return $result['request']['result'] == 1;
     }
 
@@ -329,6 +310,7 @@ class Transaction
         $api = new Api\Decline();
         $api->setTransactionId($transactionId);
         $result = $api->doRequest();
+
         return $result['request']['result'] == 1;
     }
 
@@ -337,6 +319,7 @@ class Transaction
         $api = new Api\Capture();
         $api->setTransactionId($transactionId);
         $result = $api->doRequest();
+
         return $result['request']['result'] == 1;
     }
 
@@ -345,6 +328,7 @@ class Transaction
         $api = new Api\Void();
         $api->setTransactionId($transactionId);
         $result = $api->doRequest();
+
         return $result['request']['result'] == 1;
     }
 
@@ -355,7 +339,7 @@ class Transaction
      * @param array $options An array that contains the following elements: transactionId (required), amount, description, extra1, extra2, extra3
      * @return Result\AddRecurring
      */
-    public static function addRecurring($options = array())
+    public static function addRecurring(array $options = [])
     {
         $api = new Api\AddRecurring();
 
@@ -378,7 +362,6 @@ class Transaction
         if (isset($options['extra3'])) {
             $api->setExtra3($options['extra3']);
         }
-
         $result = $api->doRequest();
 
         return new Result\AddRecurring($result);

--- a/src/Voucher.php
+++ b/src/Voucher.php
@@ -7,39 +7,37 @@ use Paynl\Result\Voucher as Result;
 
 class Voucher
 {
-
-
     /**
      * Return the voucher
      *
      * @param string $cardNumber
-     * @return \Paynl\Result\Voucher\Voucher
+     * @return Result\Voucher
      */
     public static function get($cardNumber)
     {
         $api = new Api\Balance();
         $api->setCardNumber($cardNumber);
         $result = $api->doRequest();
+
         return new Result\Voucher($result);
     }
 
     /**
      * Return the voucher
      *
-     * @param string $cardNumber
+     * @param array $options
      * @return float the current balance
      */
-    public static function balance($options = [])
+    public static function balance(array $options = [])
     {
         $api = new Api\Balance();
 
         if(isset($options['cardNumber'])){
             $api->setCardNumber($options['cardNumber']);
         }
-
         $result = $api->doRequest();
-        return $result['balance'] / 100;
 
+        return $result['balance'] / 100;
     }
 
     /**
@@ -47,7 +45,7 @@ class Voucher
      * @param array $options
      * @return bool if the charge was done succefully
      */
-    public static function charge($options = [])
+    public static function charge(array $options = [])
     {
         $api = new Api\Charge();
 
@@ -60,14 +58,17 @@ class Voucher
         if(isset($options['amount'])){
             $api->setAmount(round($options['amount'] * 100));
         }
-
         $result = $api->doRequest();
 
         return $result['request']['result'] == 1;
 
     }
 
-    public static function activate($options = []){
+    /**
+     * @param array $options
+     * @return bool
+     */
+    public static function activate(array $options = []){
         $api = new Api\Activate();
 
         if(isset($options['pincode'])){
@@ -86,6 +87,5 @@ class Voucher
 
         return $result['request']['result'] == 1;
     }
-
 
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -46,15 +46,18 @@ class ConfigTest extends PHPUnit_Framework_TestCase
             \Paynl\Config::getApiUrl('transaction')
         );
     }
+
     public function testGetCurlDefault(){
         $this->assertInstanceOf('\Curl\Curl', \Paynl\Config::getCurl());
     }
+
     public function testGetCurlCustom(){
         \Paynl\Config::setCurl(new \Paynl\Curl\Dummy());
-        $this->assertInstanceOf('\Paynl\Curl\Dummy', \Paynl\Config::getCurl());
+        $this->assertInstanceOf(\Paynl\Curl\Dummy::class, \Paynl\Config::getCurl());
     }
+
     public function testGetCurlCustomString(){
-        \Paynl\Config::setCurl('\Paynl\Curl\Dummy');
-        $this->assertInstanceOf('\Paynl\Curl\Dummy', \Paynl\Config::getCurl());
+        \Paynl\Config::setCurl(\Paynl\Curl\Dummy::class);
+        $this->assertInstanceOf(\Paynl\Curl\Dummy::class, \Paynl\Config::getCurl());
     }
 }

--- a/tests/CurrencyTest.php
+++ b/tests/CurrencyTest.php
@@ -1,24 +1,16 @@
 <?php
 
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 13-10-16
- * Time: 12:34
- */
 class CurrencyTest extends PHPUnit_Framework_TestCase
 {
     private $testApiResult;
 
-
     private function setDummyData(){
-        $this->testApiResult = file_get_contents(dirname(__FILE__).'/dummyData/currencies.json');
+        $this->testApiResult = file_get_contents(__DIR__.'/dummyData/currencies.json');
 
         $curl = new \Paynl\Curl\Dummy();
         $curl->setResult($this->testApiResult);
         \Paynl\Config::setCurl($curl);
     }
-
 
     public function testGetCurrencies(){
         \Paynl\Config::setApiToken('1234567894561234567');
@@ -28,6 +20,7 @@ class CurrencyTest extends PHPUnit_Framework_TestCase
 
         $this->assertInternalType('array', $currencies);
     }
+
     public function testGetCurrencyId(){
         \Paynl\Config::setApiToken('1234567894561234567');
         $this->setDummyData();
@@ -40,7 +33,7 @@ class CurrencyTest extends PHPUnit_Framework_TestCase
         \Paynl\Config::setApiToken('1234567894561234567');
         $this->setDummyData();
 
-        $this->setExpectedException('\Paynl\Error\NotFound');
+        $this->setExpectedException(\Paynl\Error\NotFound::class);
 
         \Paynl\Currency::getCurrencyId('ZZZ');
     }

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -4,7 +4,7 @@ class HelperTest extends PHPUnit_Framework_TestCase
 {
     public function testRequireApiTokenException()
     {
-        $this->setExpectedException('\Paynl\Error\Required\ApiToken');
+        $this->setExpectedException(\Paynl\Error\Required\ApiToken::class);
 
         \Paynl\Config::setApiToken('');
         \Paynl\Helper::requireApiToken();
@@ -12,7 +12,7 @@ class HelperTest extends PHPUnit_Framework_TestCase
 
     public function testRequireServiceIdException()
     {
-        $this->setExpectedException('\Paynl\Error\Required\ServiceId');
+        $this->setExpectedException(\Paynl\Error\Required\ServiceId::class);
 
         \Paynl\Config::setServiceId('');
         \Paynl\Helper::requireServiceId();
@@ -39,35 +39,36 @@ class HelperTest extends PHPUnit_Framework_TestCase
     public function testSplitAddress()
     {
         // @todo Straatnamen met een nummer er in bijvoorbeeld: Boulevard 1945
-        $addresses = array(
-            array('Voorstraat 2', 'Voorstraat', '2'),
-            array('Kopersteden 10', 'Kopersteden', '10'),
-            array('Kopersteden 10A', 'Kopersteden', '10A'),
-            array('Kopersteden 10 A', 'Kopersteden', '10 A'),
-            array('Kopersteden 10-A', 'Kopersteden', '10-A'),
-            array('25 American street', 'American street', '25'),
-            array('1e Wereldoorlogweg 12', '1e Wereldoorlogweg', '12'),
-            array('Lang huisnummer 1234567890', 'Lang huisnummer', '1234567890'),
-            array('2e Bothofdwarsstraat 2-44', '2e Bothofdwarsstraat', '2-44'),
-            array('Straat 145-Boven', 'Straat', '145-Boven'),
-            array('Appartementenweg 12-786', 'Appartementenweg', '12-786'),
-            array('Appartementenweg 3 hoog achter', 'Appartementenweg', '3 hoog achter'),
-            array('driesplein 22/2', 'driesplein', '22/2'),
-        );
+        $addresses = [
+            ['Voorstraat 2', 'Voorstraat', '2'],
+            ['Kopersteden 10', 'Kopersteden', '10'],
+            ['Kopersteden 10A', 'Kopersteden', '10A'],
+            ['Kopersteden 10 A', 'Kopersteden', '10 A'],
+            ['Kopersteden 10-A', 'Kopersteden', '10-A'],
+            ['25 American street', 'American street', '25'],
+            ['1e Wereldoorlogweg 12', '1e Wereldoorlogweg', '12'],
+            ['Lang huisnummer 1234567890', 'Lang huisnummer', '1234567890'],
+            ['2e Bothofdwarsstraat 2-44', '2e Bothofdwarsstraat', '2-44'],
+            ['Straat 145-Boven', 'Straat', '145-Boven'],
+            ['Appartementenweg 12-786', 'Appartementenweg', '12-786'],
+            ['Appartementenweg 3 hoog achter', 'Appartementenweg', '3 hoog achter'],
+            ['driesplein 22/2', 'driesplein', '22/2'],
+        ];
 
         foreach($addresses as $address){
             $arrAddress = \Paynl\Helper::splitAddress($address[0]);
 
-            $this->assertEquals(array(
+            $this->assertEquals([
                 $address[1],
                 $address[2]
-            ), $arrAddress);
+            ], $arrAddress);
         }
 
     }
+
     public function testObjectToArray()
     {
-        $object = (object)array('a' => '1', 'b' => '2', 'c' => '3', 'd' => '4');
+        $object = (object)['a' => '1', 'b' => '2', 'c' => '3', 'd' => '4'];
         $array = \Paynl\Helper::objectToArray($object);
 
         $this->assertInternalType('array', $array);

--- a/tests/PaymentmethodsTest.php
+++ b/tests/PaymentmethodsTest.php
@@ -1,18 +1,11 @@
 <?php
 
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 15-4-2016
- * Time: 16:22
- */
 class PaymentmethodsTest extends PHPUnit_Framework_TestCase
 {
     private $testApiResult;
 
-
     private function setDummyData(){
-        $this->testApiResult = file_get_contents(dirname(__FILE__).'/dummyData/getService.json');
+        $this->testApiResult = file_get_contents(__DIR__.'/dummyData/getService.json');
 
         $curl = new \Paynl\Curl\Dummy();
         $curl->setResult($this->testApiResult);
@@ -23,17 +16,19 @@ class PaymentmethodsTest extends PHPUnit_Framework_TestCase
         $this->setDummyData();
         \Paynl\Config::setApiToken('123456789012345678901234567890');
         \Paynl\Config::setServiceId('');
-        $this->setExpectedException('\Paynl\Error\Required\ServiceId');
+        $this->setExpectedException(\Paynl\Error\Required\ServiceId::class);
         \Paynl\Paymentmethods::getList();
 
     }
+
     public function testGetPaymentMethodsNoToken(){
         $this->setDummyData();
         \Paynl\Config::setApiToken('');
         \Paynl\Config::setServiceId('SL-1234-5678');
-        $this->setExpectedException('\Paynl\Error\Required\Apitoken');
+        $this->setExpectedException(\Paynl\Error\Required\ApiToken::class);
         \Paynl\Paymentmethods::getList();
     }
+
     public function testGetPaymentMethods(){
         $this->setDummyData();
 
@@ -50,13 +45,14 @@ class PaymentmethodsTest extends PHPUnit_Framework_TestCase
             $this->assertArrayHasKey('visibleName', $paymentMethod);
         }
     }
+
     public function testGetPaymentMethodsCountry(){
         $this->setDummyData();
 
         \Paynl\Config::setServiceId('SL-1234-5678');
         \Paynl\Config::setApiToken('123456789012345678901234567890');
 
-        $list = \Paynl\Paymentmethods::getList(array('country' => 'NL'));
+        $list = \Paynl\Paymentmethods::getList(['country' => 'NL']);
 
         $this->assertInternalType('array',$list);
 
@@ -64,14 +60,14 @@ class PaymentmethodsTest extends PHPUnit_Framework_TestCase
             $this->assertArrayHasKey('id', $paymentMethod);
             $this->assertArrayHasKey('name', $paymentMethod);
             $this->assertArrayHasKey('visibleName', $paymentMethod);
-            $this->assertTrue(in_array('ALL',$paymentMethod['countries']) ||
-                              in_array('NL',$paymentMethod['countries']),
+            $this->assertTrue(in_array('ALL', $paymentMethod['countries'], true) ||
+                              in_array('NL', $paymentMethod['countries'], true),
                 'Returned paymentMethod invalid for this country');
         }
     }
 
     public function testGetBanksNoToken(){
-        $this->setExpectedException('\Paynl\Error\Required\Apitoken');
+        $this->setExpectedException(\Paynl\Error\Required\ApiToken::class);
         $this->setDummyData();
 
         \Paynl\Config::setServiceId('SL-1234-5678');
@@ -81,7 +77,7 @@ class PaymentmethodsTest extends PHPUnit_Framework_TestCase
     }
 
     public function testGetBanksNoServiceId(){
-        $this->setExpectedException('\Paynl\Error\Required\ServiceId');
+        $this->setExpectedException(\Paynl\Error\Required\ServiceId::class);
         $this->setDummyData();
 
         \Paynl\Config::setServiceId('');
@@ -106,6 +102,7 @@ class PaymentmethodsTest extends PHPUnit_Framework_TestCase
             $this->assertArrayHasKey('visibleName', $bank);
         }
     }
+
     public function testGetBanksInvalidPaymentMethod(){
         $this->setDummyData();
 

--- a/tests/RefundTest.php
+++ b/tests/RefundTest.php
@@ -1,24 +1,19 @@
 <?php
 
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 12-10-16
- * Time: 18:07
- */
 class RefundTest extends PHPUnit_Framework_TestCase
 {
     private $testApiResult;
 
     private function setDummyData($name)
     {
-        $this->testApiResult = file_get_contents(dirname(__FILE__) . '/dummyData/Refund/' . $name . '.json');
+        $this->testApiResult = file_get_contents(__DIR__ . '/dummyData/Refund/' . $name . '.json');
         $curl = new \Paynl\Curl\Dummy();
         $curl->setResult($this->testApiResult);
         \Paynl\Config::setCurl($curl);
     }
+
     private function refundAddFull(){
-        return \Paynl\Refund::add(array(
+        return \Paynl\Refund::add([
             'amount' => 1,
             'bankAccountHolder' => 'N Klant',
             'bankAccountNumber' => '123456789',
@@ -34,32 +29,35 @@ class RefundTest extends PHPUnit_Framework_TestCase
             'orderId' => '1',
             'currency' => '1',
             'processDate' => '12-12-2017',
-        ));
+        ]);
     }
+
     public function testRefundAddNoServiceId(){
         $this->setDummyData('refund');
-        $this->setExpectedException('\Paynl\Error\Required\ServiceId');
+        $this->setExpectedException(\Paynl\Error\Required\ServiceId::class);
 
         \Paynl\Config::setApiToken('123456789012345678901234567890');
         \Paynl\Config::setServiceId('');
 
         $this->refundAddFull();
     }
+
     public function testRefundAddNoToken(){
         $this->setDummyData('refund');
-        $this->setExpectedException('\Paynl\Error\Required\ApiToken');
+        $this->setExpectedException(\Paynl\Error\Required\ApiToken::class);
 
         \Paynl\Config::setApiToken('');
         \Paynl\Config::setServiceId('SL-1234-5678');
 
         $this->refundAddFull();
     }
+
     public function testRefundAdd(){
         $this->setDummyData('refund');
         \Paynl\Config::setApiToken('123456789012345678901234567890');
         \Paynl\Config::setServiceId('SL-1234-5678');
         $result = $this->refundAddFull();
-        $this->assertInstanceOf('\Paynl\Result\Refund\Add', $result);
+        $this->assertInstanceOf(\Paynl\Result\Refund\Add::class, $result);
         $this->assertStringStartsWith('RF-',$result->getRefundId());
     }
 }

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -1,18 +1,12 @@
 <?php
 
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 20-4-2016
- * Time: 14:06
- */
 class TransactionTest extends PHPUnit_Framework_TestCase
 {
     private $testApiResult;
 
     private function setDummyData($name)
     {
-        $this->testApiResult = file_get_contents(dirname(__FILE__) . '/dummyData/Transaction/' . $name . '.json');
+        $this->testApiResult = file_get_contents(__DIR__ . '/dummyData/Transaction/' . $name . '.json');
         $curl = new \Paynl\Curl\Dummy();
         $curl->setResult($this->testApiResult);
         \Paynl\Config::setCurl($curl);
@@ -26,7 +20,7 @@ class TransactionTest extends PHPUnit_Framework_TestCase
     private function startTransactionFull()
     {
         $this->setDummyData('startOk');
-        $result = \Paynl\Transaction::start(array(
+        $result = \Paynl\Transaction::start([
             // required
             'amount' => 10,
             'returnUrl' => '/return.php',
@@ -47,39 +41,39 @@ class TransactionTest extends PHPUnit_Framework_TestCase
             'transferType' => 'transaction',
             'transferValue' => '123441x12341',
             'deliveryDate' => 'tomorrow', // in case of tickets for an event, use the event date here
-            'products' => array(
-                array(
+            'products' => [
+                [
                     'id' => 1,
                     'name' => 'een product',
                     'price' => 5,
                     'tax' => 0.87,
                     'qty' => 1,
-                ),
-                array(
+                ],
+                [
                     'id' => 2,
                     'name' => 'ander product',
                     'price' => 5,
                     'tax' => 0.87,
                     'qty' => 1,
-                )
-            ),
+                ]
+            ],
             'language' => 'EN',
-            'enduser' => array(
+            'enduser' => [
                 'initials' => 'T',
                 'lastName' => 'Test',
                 'gender' => 'M',
                 'birthDate' => '14-05-1999',
                 'phoneNumber' => '0612345678',
                 'emailAddress' => 'test@test.nl',
-            ),
-            'address' => array(
+            ],
+            'address' => [
                 'streetName' => 'Test',
                 'houseNumber' => '10',
                 'zipCode' => '1234AB',
                 'city' => 'Test',
                 'country' => 'NL',
-            ),
-            'invoiceAddress' => array(
+            ],
+            'invoiceAddress' => [
                 'initials' => 'IT',
                 'lastName' => 'ITEST',
                 'streetName' => 'Istreet',
@@ -88,14 +82,14 @@ class TransactionTest extends PHPUnit_Framework_TestCase
                 'city' => 'ITest',
                 'country' => 'NL',
                 'gender' => 'F'
-            ),
-        ));
+            ],
+        ]);
         return $result;
     }
 
     public function testStartNoToken()
     {
-        $this->setExpectedException('\Paynl\Error\Required\ApiToken');
+        $this->setExpectedException(\Paynl\Error\Required\ApiToken::class);
 
         \Paynl\Config::setApiToken('');
         \Paynl\Config::setServiceId('SL-1234-5678');
@@ -105,7 +99,7 @@ class TransactionTest extends PHPUnit_Framework_TestCase
 
     public function testStartNoServiceId()
     {
-        $this->setExpectedException('\Paynl\Error\Required\ServiceId');
+        $this->setExpectedException(\Paynl\Error\Required\ServiceId::class);
 
         \Paynl\Config::setApiToken('123456789012345678901234567890');
         \Paynl\Config::setServiceId('');
@@ -115,28 +109,28 @@ class TransactionTest extends PHPUnit_Framework_TestCase
 
     public function testStartNoAmount()
     {
-        $this->setExpectedException('\Paynl\Error\Required');
+        $this->setExpectedException(\Paynl\Error\Required::class);
         $this->setDummyData('startOk');
         \Paynl\Config::setApiToken('123456789012345678901234567890');
         \Paynl\Config::setServiceId('SL-1234-5678');
 
-        \Paynl\Transaction::start(array(
+        \Paynl\Transaction::start([
             'returnUrl' => '/return.php',
             'ipaddress' => '127.0.0.1',
-        ));
+        ]);
     }
 
     public function testStartNoReturn()
     {
-        $this->setExpectedException('\Paynl\Error\Required');
+        $this->setExpectedException(\Paynl\Error\Required::class);
         $this->setDummyData('startOk');
         \Paynl\Config::setApiToken('123456789012345678901234567890');
         \Paynl\Config::setServiceId('SL-1234-5678');
 
-        \Paynl\Transaction::start(array(
+        \Paynl\Transaction::start([
             'amount' => 10,
             'ipaddress' => '127.0.0.1',
-        ));
+        ]);
     }
 
     public function testStartMinumumOk()
@@ -145,18 +139,18 @@ class TransactionTest extends PHPUnit_Framework_TestCase
         \Paynl\Config::setServiceId('SL-1234-5678');
 
         $this->setDummyData('startOk');
-        $result = \Paynl\Transaction::start(array(
+        $result = \Paynl\Transaction::start([
             'amount' => 10,
             'returnUrl' => '/return.php',
             'ipaddress' => '127.0.0.1',
-        ));
+        ]);
 
         $this->validateStartResult($result);
     }
 
     private function validateStartResult($result)
     {
-        $this->assertInstanceOf('\Paynl\Result\Transaction\Start', $result);
+        $this->assertInstanceOf(\Paynl\Result\Transaction\Start::class, $result);
 
         /**
          * @var $result \Paynl\Result\Transaction\Start
@@ -185,7 +179,7 @@ class TransactionTest extends PHPUnit_Framework_TestCase
 
         $transaction = Paynl\Transaction::get('645958819Xdd3ea1');
 
-        $this->assertInstanceOf('\Paynl\Result\Transaction\Transaction', $transaction);
+        $this->assertInstanceOf(\Paynl\Result\Transaction\Transaction::class, $transaction);
 
     }
 
@@ -198,7 +192,7 @@ class TransactionTest extends PHPUnit_Framework_TestCase
         $_GET['orderId'] = "645958819Xdd3ea1";
 
         $transaction = Paynl\Transaction::getForReturn();
-        $this->assertInstanceOf('\Paynl\Result\Transaction\Transaction', $transaction);
+        $this->assertInstanceOf(\Paynl\Result\Transaction\Transaction::class, $transaction);
     }
 
     public function testGetForExchange()
@@ -210,7 +204,7 @@ class TransactionTest extends PHPUnit_Framework_TestCase
         $_GET['order_id'] = "645958819Xdd3ea1";
 
         $transaction = Paynl\Transaction::getForExchange();
-        $this->assertInstanceOf('\Paynl\Result\Transaction\Transaction', $transaction);
+        $this->assertInstanceOf(\Paynl\Result\Transaction\Transaction::class, $transaction);
     }
 
     public function testGetForExchangePost()
@@ -224,7 +218,7 @@ class TransactionTest extends PHPUnit_Framework_TestCase
         $_POST['order_id'] = "645958819Xdd3ea1";
 
         $transaction = Paynl\Transaction::getForExchange();
-        $this->assertInstanceOf('\Paynl\Result\Transaction\Transaction', $transaction);
+        $this->assertInstanceOf(\Paynl\Result\Transaction\Transaction::class, $transaction);
     }
 
     public function testRefund()
@@ -242,11 +236,12 @@ class TransactionTest extends PHPUnit_Framework_TestCase
     {
         \Paynl\Config::setApiToken('123456789012345678901234567890');
 
-        $this->setExpectedException('\Paynl\Error\Api');
+        $this->setExpectedException(\Paynl\Error\Api::class);
 
         $this->setDummyData('Result/refundError');
         \Paynl\Transaction::refund('645958819Xdd3ea1', 5, 'Description', new DateTime());
     }
+
     public function testApprove(){
         \Paynl\Config::setApiToken('123456789012345678901234567890');
 
@@ -259,6 +254,7 @@ class TransactionTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(true, $result);
     }
+
     public function testApprovePaidTransaction(){
         \Paynl\Config::setApiToken('123456789012345678901234567890');
 
@@ -267,9 +263,10 @@ class TransactionTest extends PHPUnit_Framework_TestCase
         $transaction = Paynl\Transaction::get('12456789');
 
         $this->setDummyData('Result/approve');
-        $this->setExpectedException('\Paynl\Error\Error');
+        $this->setExpectedException(\Paynl\Error\Error::class);
         $transaction->approve();
     }
+
     public function testDecline(){
         \Paynl\Config::setApiToken('123456789012345678901234567890');
 
@@ -282,6 +279,7 @@ class TransactionTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(true, $result);
     }
+
     public function testDeclinePaidTransaction(){
         \Paynl\Config::setApiToken('123456789012345678901234567890');
 
@@ -290,20 +288,22 @@ class TransactionTest extends PHPUnit_Framework_TestCase
         $transaction = Paynl\Transaction::get('12456789');
 
         $this->setDummyData('Result/decline');
-        $this->setExpectedException('\Paynl\Error\Error');
+        $this->setExpectedException(\Paynl\Error\Error::class);
         $transaction->decline();
     }
+
     public function testApproveWithoutTransactionId(){
         \Paynl\Config::setApiToken('123456789012345678901234567890');
 
-        $this->setExpectedException('\Paynl\Error\Required');
+        $this->setExpectedException(\Paynl\Error\Required::class);
 
         \Paynl\Transaction::approve('');
     }
+
     public function testDeclineWithoutTransactionId(){
         \Paynl\Config::setApiToken('123456789012345678901234567890');
 
-        $this->setExpectedException('\Paynl\Error\Required');
+        $this->setExpectedException(\Paynl\Error\Required::class);
 
         \Paynl\Transaction::decline('');
     }

--- a/tests/ValidateTest.php
+++ b/tests/ValidateTest.php
@@ -1,17 +1,11 @@
 <?php
 
-/**
- * Created by PhpStorm.
- * User: andy
- * Date: 26-4-16
- * Time: 19:30
- */
 class ValidateTest extends PHPUnit_Framework_TestCase
 {
     private $testApiResult;
 
     private function setDummyData($name){
-        $this->testApiResult = file_get_contents(dirname(__FILE__).'/dummyData/Validate/'.$name.'.json');
+        $this->testApiResult = file_get_contents(__DIR__.'/dummyData/Validate/'.$name.'.json');
         $curl = new \Paynl\Curl\Dummy();
         $curl->setResult($this->testApiResult);
         \Paynl\Config::setCurl($curl);
@@ -23,6 +17,7 @@ class ValidateTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals(true, $result);
     }
+
     public function testIsPayServerIpNo(){
         $this->setDummyData('isPayServerIpNo');
 


### PR DESCRIPTION
This is mainly a cleanup of the code itself (no added/removed/changes in features)

- a few strict type checkings here and there where possible
- do not redeclare when not needed
- usage of Datetime variables unified (only format to string when needed)

_actual_ style changes:
- added docblocks to all the methods
- if-only branches where possible (no more else)
- ordered the methods in a sane manner
- unified usage of Exception throwing (no more renaming between usages)
- removed superfluous Phpstorm docblocks
- use short array notation (array vs `[`-`]`)
- unified alot of the `Required`-errors (dutch vs english et al)

I've also added a `CurlInterface` which the `Curl\Dummy` now implements. This allows users of the SDK to know what to inject... (the `Curl\Curl`-class normally used exposes a lot more than needed which comes to light when looking at the interface :smile: )

I'd also like to propose to unify the result checks to be more strict (the various `return $result['request']['result'] == 1`-lines)

@andypieters What to you think? It might seem like a large diff but its mostly moving around lines and unifying layout of the code... 

*all tests still pass with flying colors*