### PR TITLE
Voucher balance check pincode

### DIFF
--- a/src/Voucher.php
+++ b/src/Voucher.php
@@ -35,6 +35,9 @@ class Voucher
         if(isset($options['cardNumber'])){
             $api->setCardNumber($options['cardNumber']);
         }
+        if(isset($options['pincode'])){
+            $api->setPincode($options['pincode']);
+        }
         $result = $api->doRequest();
 
         return $result['balance'] / 100;


### PR DESCRIPTION
Fashioncheque requires a pincode to retrieve the balance of the card. This is currently unsupported, because the pincode is not being set.