### PR TITLE
retrieve instore payment hash for transactions started with Transaction::start()

### DIFF
--- a/src/Result/Transaction/Start.php
+++ b/src/Result/Transaction/Start.php
@@ -34,4 +34,12 @@ class Start extends Result
     {
         return $this->data['transaction']['paymentReference'];
     }
+    
+    /**
+     * @return mixed The terminal hash for this transaction, use this for Instore::Status
+     */
+    public function getHash()
+    {
+        return $this->data['terminal']['hash'];
+    }
 }


### PR DESCRIPTION
When starting a new instore transaction with Transaction::start() the hash needed to retrieve the instore payment receipt and status is returned in the payload, but cannot be accessed from within the Transaction Result. The method getHash() has been added to facilitate this. Now both the TransactionId and the Hash can be retrieved without the need for a second call.