### PR TITLE
PAY-65: Various fixes

### DIFF
--- a/samples/functions.php
+++ b/samples/functions.php
@@ -8,13 +8,15 @@ require_once  __DIR__ . '/../vendor/autoload.php';
 $amountIncludingVat = 143.34;
 $vatAmount = 23.39;
 
-echo '<pre/>' . PHP_EOL .
+echo '<pre/><h3>paynl_calc_vat_percentage & paynl_determine_vat_class</h3>' . PHP_EOL;
+echo  PHP_EOL .
     'Amount including VAT: ' . number_format($amountIncludingVat, 2) . PHP_EOL .
     'VAT amount: ' . number_format($vatAmount, 2) . PHP_EOL .
     'VAT percentage: ' . number_format(paynl_calc_vat_percentage($amountIncludingVat, $vatAmount), 2) . PHP_EOL .
     'VAT Class: ' . paynl_determine_vat_class($amountIncludingVat, $vatAmount) . PHP_EOL
 ;
 
+echo '<h3>paynl_split_address</h3>' . PHP_EOL;
 $address1 = 'Jan Campertlaan 10';
 $address2 = 'SomeLane 14b';
 $address3 = '124 West Avenue';

--- a/samples/index.php
+++ b/samples/index.php
@@ -47,8 +47,8 @@ declare(strict_types=1);
                     foreach ($samples as $sample) {
                         echo sprintf(
                             '<div>
-                            <a href="%s" target="_blank">%s</a>
-                        </div>' . PHP_EOL,
+                                <a href="%s" target="_blank">%s</a>
+                            </div>' . PHP_EOL,
                             ltrim(str_replace(__DIR__, '', $sample), DIRECTORY_SEPARATOR),
                             str_replace(['-', '.php'], [' ', ''], ucfirst(basename($sample)))
                         );
@@ -57,6 +57,10 @@ declare(strict_types=1);
                 }
             }
             ?>
+            <h2>Functions</h2>
+            <div>
+                <a href="functions.php" target="_blank">overview</a>
+            </div>
         </div>
     </body>
 </html>

--- a/samples/transactions/create-new.php
+++ b/samples/transactions/create-new.php
@@ -15,14 +15,15 @@ use Zend\Hydrator\ClassMethods;
 
 $transaction = (new Hydrator\Transaction)->hydrate([
     'serviceId' => 'SL-3490-4320',
-    'amount' => (new ClassMethods())->hydrate([
+    'amount' => [
         'amount'   => 34500,
         'currency' => 'USD'
-    ], new Model\Amount()),
+    ],
     'returnUrl' => 'https://www.pay.nl/return-url',
     'exchangeUrl' => 'https://www.pay.nl/exchange-url',
     'paymentMethod' => [
         'id' => 10,
+        'subId' => 2,
         'name' => 'Rabobank',
     ],
     'testMode' => 0,
@@ -35,7 +36,7 @@ $transaction = (new Hydrator\Transaction)->hydrate([
     'description' => 'Test description',
     'orderNumber' => 'ORD000000',
     'endUserId' => 0,
-    'customer' => (new Hydrator\Customer())->hydrate([
+    'customer' => [
         'initials' => 'B',
         'firstName' => 'Bruce',
         'lastName' => 'Wayne',
@@ -45,21 +46,21 @@ $transaction = (new Hydrator\Transaction)->hydrate([
         'phone' => '612121212',
         'email' => 'b.wayne@wayne-enterprises.com',
         'trustLevel' => '-5',
-        'bankAccount' => (new Hydrator\BankAccount())->hydrate([
+        'bankAccount' => [
             'iban' => 'NL91ABNA0417164300',
             'bic' => 'INGBNL2A',
             'owner' => 'Bruce Wayne'
-        ], new Model\BankAccount()),
+        ],
         'reference' => '123456789',
         'language' => 'NL',
-    ], new Model\Customer()),
-    'company' => (new ClassMethods())->hydrate([
+    ],
+    'company' => [
         'name' => 'Wayne Enterprises Inc.',
         'coc' => '12345678',
         'vat' => '24456789B01',
         'countryCode' => 'US'
-    ], new Model\Company()),
-    'address' => (new Hydrator\Address())->hydrate([
+    ],
+    'address' => [
         'streetName' => 'Mountain Drive',
         'streetNumber' => '1007',
         'zipCode' => '24857',
@@ -68,8 +69,8 @@ $transaction = (new Hydrator\Transaction)->hydrate([
         'countryCode' => 'US',
         'initials' => 'B',
         'lastName' => 'Wayne'
-    ], new Model\Address()),
-    'billingAddress' => (new Hydrator\Address())->hydrate([
+    ],
+    'billingAddress' => [
         'streetName' => 'Mountain Drive',
         'streetNumber' => '1007',
         'zipCode' => '24857',
@@ -78,20 +79,20 @@ $transaction = (new Hydrator\Transaction)->hydrate([
         'countryCode' => 'US',
         'initials' => 'B',
         'lastName' => 'Wayne'
-    ], new Model\Address()),
+    ],
     'products' => [
-        (new Hydrator\Product())->hydrate([
+        [
             'id' => 'P-1000-00021',
             'description' => 'Tumbler',
-            'price' => (new ClassMethods())->hydrate([
+            'price' => [
                 'amount' => '2500000',
                 'currency' => 'USD'
-            ], new Model\Amount()),
+            ],
             'quantity' => 1,
             'vat' => 'N'
-        ], new Model\Product())
+        ],
     ],
-    'statistics' => (new Hydrator\Statistics())->hydrate([
+    'statistics' => [
         'promoterId' => 0,
         'info' => 'This is information',
         'tool' => 'I use this tool',
@@ -101,7 +102,7 @@ $transaction = (new Hydrator\Transaction)->hydrate([
         'transferData' => [
             'dataaaaa'
         ]
-    ], new Model\Statistics()),
+    ],
 ], new Model\Transaction());
 
 $authAdapter = getAuthAdapter();

--- a/src/Hydrator/PaymentMethod.php
+++ b/src/Hydrator/PaymentMethod.php
@@ -19,6 +19,8 @@ class PaymentMethod extends AbstractHydrator
     {
         $this->validateGivenObject($object, PaymentMethodModel::class);
 
+        $data['image'] = $data['image'] ?? '';
+
         if (true === array_key_exists('subId', $data) && true === empty($data['subId'])) {
             unset($data['subId']);
         }

--- a/src/Hydrator/Transaction.php
+++ b/src/Hydrator/Transaction.php
@@ -19,6 +19,7 @@ use PayNL\Sdk\Model\{
 use PayNL\Sdk\Hydrator\{
     Address as AddressHydrator,
     Customer as CustomerHydrator,
+    PaymentMethod as PaymentMethodHydrator,
     Product as ProductHydrator,
     Status as StatusHydrator,
     Statistics as StatisticsHydrator
@@ -56,7 +57,7 @@ class Transaction extends AbstractHydrator
         $data['exchangeUrl'] = $data['exchangeUrl'] ?? '';
 
         if (true === array_key_exists('paymentMethod', $data) && true === is_array($data['paymentMethod'])) {
-            $data['paymentMethod'] = (new ClassMethods())->hydrate($data['paymentMethod'], new PaymentMethod());
+            $data['paymentMethod'] = (new PaymentMethodHydrator())->hydrate($data['paymentMethod'], new PaymentMethod());
         }
         foreach (['address', 'billingAddress'] as $addressKey) {
             if (true === array_key_exists($addressKey, $data) && true === is_array($data[$addressKey])) {

--- a/src/Model/PaymentMethod.php
+++ b/src/Model/PaymentMethod.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PayNL\Sdk\Model;
 
 use JsonSerializable;
+use PayNL\Sdk\Exception\InvalidArgumentException;
 
 /**
  * Class PaymentMethod
@@ -21,9 +22,9 @@ class PaymentMethod implements ModelInterface, JsonSerializable
     protected $id;
 
     /**
-     * @var integer|null
+     * @var string
      */
-    protected $subId;
+    protected $subId = '';
 
     /**
      * @var string
@@ -70,20 +71,32 @@ class PaymentMethod implements ModelInterface, JsonSerializable
     }
 
     /**
-     * @return int
+     * @return string
      */
-    public function getSubId(): ?int
+    public function getSubId(): string
     {
-        return $this->subId;
+        return (string) $this->subId;
     }
 
     /**
-     * @param int $subId
+     * @param mixed $subId
      *
      * @return PaymentMethod
      */
-    public function setSubId(int $subId): self
+    public function setSubId($subId): self
     {
+        if (true === is_int($subId)) {
+            $subId = (string) $subId;
+        } elseif (false === is_string($subId)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    '%s expects argument given to be a string or integer, %s given',
+                    __METHOD__,
+                    is_object($subId) ? get_class($subId) : gettype($subId)
+                )
+            );
+        }
+
         $this->subId = $subId;
         return $this;
     }


### PR DESCRIPTION
PAY-65: Fix PaymentMethod hydrator so the image URL is by default an empty string when null is given in the data array +
Use PaymentMethod hydrator is Transaction hydrator to populate the object +
Change member subId within PaymentMethod model to string instead of integer +
Adjust create new transaction sample to make it more readable and add subId +
Add functions to samples page +
Add function name(s) as title in the functions sample page