### PR TITLE
PAY-65: Adjustments based on feedback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,9 @@
   }],
   "require": {
     "php": "^7.1",
-    "ext-json": "*",
     "ext-curl": "*",
+    "ext-json": "*",
+    "doctrine/collections": "^1.6",
     "psr/http-message": "~1.0",
     "ralouphie/getallheaders": "^2.0.5 || ^3.0.0",
     "symfony/serializer": "^4.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d01dfa99cff35560e4ebc3f0cb9688d3",
+    "content-hash": "167990671341b5ca9125039c8d58853b",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -35,7 +35,78 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
+            "abandoned": "psr/container",
             "time": "2017-02-14T19:40:03+00:00"
+        },
+        {
+            "name": "doctrine/collections",
+            "version": "1.6.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "6b1e4b2b66f6d6e49983cebfe23a21b7ccc5b0d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/6b1e4b2b66f6d6e49983cebfe23a21b7ccc5b0d7",
+                "reference": "6b1e4b2b66f6d6e49983cebfe23a21b7ccc5b0d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpstan/phpstan-shim": "^0.9.2",
+                "phpunit/phpunit": "^7.0",
+                "vimeo/psalm": "^3.2.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Collections\\": "lib/Doctrine/Common/Collections"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Collections library that adds additional functionality on top of PHP arrays.",
+            "homepage": "https://www.doctrine-project.org/projects/collections.html",
+            "keywords": [
+                "array",
+                "collections",
+                "iterators",
+                "php"
+            ],
+            "time": "2019-11-13T13:07:11+00:00"
         },
         {
             "name": "psr/container",
@@ -5555,8 +5626,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^7.1",
-        "ext-json": "*",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "ext-json": "*"
     },
     "platform-dev": {
         "ext-simplexml": "*"

--- a/samples/config.php
+++ b/samples/config.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 use PayNL\Sdk\Config;
 
 return [
-//    Config::KEY_API_URL  => 'https://rest.idefix-rest-api-mike.ian.dev.pay.nl/v1/',
-    Config::KEY_API_URL  => 'https://rest.idefix.mike.dev.pay.nl/v1/',
+    Config::KEY_API_URL  => 'https://rest.idefix.mike.dev.pay.nl/',
+    Config::KEY_VERSION  => 1,
     Config::KEY_USERNAME => 'token',
     Config::KEY_PASSWORD => '68babb1a525f6116b387231af9d2e4413a6c8f61',
 

--- a/samples/config.php
+++ b/samples/config.php
@@ -20,6 +20,6 @@ return [
     'serviceId'             => 'SL-3167-1271',
     'terminalId'            => 'TH-3640-7060',
     'terminalTransactionId' => 'TT-9054-1003-5510',
-    'transactionId'         => 'EX-3172-0377-7620',
+    'transactionId'         => 'EX-7436-1212-5160',
     'voucherNumber'         => '1234567800273867546',
 ];

--- a/samples/errors/qr-encode.php
+++ b/samples/errors/qr-encode.php
@@ -32,12 +32,6 @@ $response = (new Api($authAdapter))
 ;
 
 /** @var ErrorsModel $errors */
-$errors = $response->getBody();
-
-echo '<pre/>' . PHP_EOL .
-    'Nr of errors: ' . var_export(count($errors), true) . PHP_EOL
-;
-echo 'Errors: ';
-foreach ($errors as $key => $value) {
-    echo var_export([$key, $value], true) . PHP_EOL;
-}
+echo '<pre/>' . PHP_EOL;
+echo 'Has errors: ' . var_export($response->hasErrors(), true) . PHP_EOL . PHP_EOL;
+echo 'Errors: ' . PHP_EOL . $response->getErrors() . PHP_EOL;

--- a/samples/transactions/create-new.php
+++ b/samples/transactions/create-new.php
@@ -28,8 +28,7 @@ $transaction = (new Hydrator\Transaction)->hydrate([
     ],
     'testMode' => 0,
     'transferType' => 'merchant',
-    //TODO, delete for goto live - is production merchant ID!!
-    'transferValue' => 'M-3421-2120',
+    'transferValue' => 'M-0000-0000',
     'invoiceDate' => (new DateTime())->sub(new DateInterval('P3D'))->format(DateTime::ATOM),
     'deliveryDate' => (new DateTime())->format(DateTime::ATOM),
     'expiresAt' => (new DateTime())->add(new DateInterval('P7D'))->format(DateTime::ATOM),

--- a/src/Api.php
+++ b/src/Api.php
@@ -66,8 +66,9 @@ class Api
      */
     protected function initClient(): void
     {
+        $cnf = Config::getInstance();
         $config = [
-            'base_uri' => Config::getInstance()->getApiUrl(),
+            'base_uri' => rtrim($cnf->getApiUrl(), '/') . "/v{$cnf->getVersion()}/",
         ];
 
         $this->client = new Client($config);

--- a/src/Config.php
+++ b/src/Config.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace PayNL\Sdk;
 
-use PayNL\Sdk\Exception\InvalidArgumentException;
-use PayNL\Sdk\Exception\LogicException;
-use PayNL\Sdk\Exception\UnexpectedValueException;
+use PayNL\Sdk\Exception\{
+    LogicException,
+    UnexpectedValueException,
+    InvalidArgumentException
+};
 
 /**
  * Class Config
@@ -19,6 +21,7 @@ class Config
      * Configuration key constants definition
      */
     public const KEY_API_URL = 'api_url';
+    public const KEY_VERSION = 'version';
     public const KEY_USERNAME = 'username';
     public const KEY_PASSWORD = 'password';
 
@@ -32,6 +35,7 @@ class Config
      */
     protected $data = [
         self::KEY_API_URL  => '',
+        self::KEY_VERSION  => 1,
         self::KEY_USERNAME => '',
         self::KEY_PASSWORD => '',
     ];
@@ -66,16 +70,23 @@ class Config
         throw new LogicException('Config may not be cloned');
     }
 
+    /**
+     * @param array $config
+     *
+     * @return void
+     */
     public function load(array $config): void
     {
         if (false === array_key_exists(self::KEY_API_URL, $config)
+            || false === array_key_exists(self::KEY_VERSION, $config)
             || false === array_key_exists(self::KEY_USERNAME, $config)
             || false === array_key_exists(self::KEY_PASSWORD, $config)
         ) {
             throw new InvalidArgumentException(
                 sprintf(
-                    '%s, %s and %s need to be defined',
+                    '%s, %s, %s and %s need to be defined',
                     self::KEY_API_URL,
+                    self::KEY_VERSION,
                     self::KEY_USERNAME,
                     self::KEY_PASSWORD
                 )
@@ -123,6 +134,14 @@ class Config
     public function getApiUrl(): string
     {
         return $this->get(self::KEY_API_URL);
+    }
+
+    /**
+     * @return integer
+     */
+    public function getVersion(): int
+    {
+        return (int)$this->get(self::KEY_VERSION);
     }
 
     /**

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayNL\Sdk\Exception;
+
+/**
+ * Class RuntimeException
+ *
+ * @package PayNL\Sdk\Exception
+ */
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Hydrator/Currencies.php
+++ b/src/Hydrator/Currencies.php
@@ -26,8 +26,6 @@ class Currencies extends AbstractHydrator
     {
         $this->validateGivenObject($object, CurrenciesModel::class);
 
-        // "reset" total
-        $data['total'] = 0;
         foreach ($data['currencies'] as $key => $currency) {
             $data['currencies'][$key] = (new SimpleHydrator())->hydrate($currency, new CurrencyModel());
         }

--- a/src/Hydrator/PaymentMethods.php
+++ b/src/Hydrator/PaymentMethods.php
@@ -26,7 +26,6 @@ class PaymentMethods extends AbstractHydrator
     {
         $this->validateGivenObject($object, PaymentMethodsModel::class);
 
-        // "reset" total
         foreach ($data['paymentMethods'] as $key => $paymentMethod) {
             $data['paymentMethods'][$key] = (new PaymentMethodHydrator())->hydrate($paymentMethod, new PaymentMethodModel());
         }

--- a/src/Hydrator/Services.php
+++ b/src/Hydrator/Services.php
@@ -26,8 +26,6 @@ class Services extends AbstractHydrator
     {
         $this->validateGivenObject($object, ServicesModel::class);
 
-        // "reset" total
-        $data['total'] = 0;
         foreach ($data['services'] as $key => $currency) {
             $data['services'][$key] = (new ServiceHydrator())->hydrate($currency, new ServiceModel());
         }

--- a/src/Hydrator/Status.php
+++ b/src/Hydrator/Status.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PayNL\Sdk\Hydrator;
 
+use Exception;
 use PayNL\Sdk\DateTime;
 use PayNL\Sdk\Model\Status as StatusModel;
 
@@ -16,6 +17,8 @@ class Status extends AbstractHydrator
 {
     /**
      * @inheritDoc
+     *
+     * @throws Exception
      *
      * @return StatusModel
      */

--- a/src/Hydrator/Terminals.php
+++ b/src/Hydrator/Terminals.php
@@ -26,8 +26,6 @@ class Terminals extends AbstractHydrator
     {
         $this->validateGivenObject($object, TerminalsModel::class);
 
-        // "reset" total
-        $data['total'] = 0;
         foreach ($data['terminals'] as $key => $terminal) {
             if (false === ($terminal instanceof TerminalModel)) {
                 $data['terminals'][$key] = (new TerminalHydrator())->hydrate($terminal, new TerminalModel());

--- a/src/Hydrator/Transaction.php
+++ b/src/Hydrator/Transaction.php
@@ -13,7 +13,7 @@ use PayNL\Sdk\Model\{
     PaymentMethod,
     Product,
     Statistics,
-    Status,
+    TransactionStatus,
     Transaction as TransactionModel
 };
 use PayNL\Sdk\Hydrator\{
@@ -54,7 +54,7 @@ class Transaction extends AbstractHydrator
         $this->validateGivenObject($object, TransactionModel::class);
 
         if (true === array_key_exists('status', $data) && true === is_array($data['status'])) {
-            $data['status'] =  (new StatusHydrator())->hydrate($data['status'], new Status());
+            $data['status'] =  (new StatusHydrator())->hydrate($data['status'], new TransactionStatus());
         }
 
         $data['exchangeUrl'] = $data['exchangeUrl'] ?? '';

--- a/src/Model/Currencies.php
+++ b/src/Model/Currencies.php
@@ -4,52 +4,23 @@ declare(strict_types=1);
 
 namespace PayNL\Sdk\Model;
 
-use Countable, ArrayAccess, IteratorAggregate, ArrayIterator;
+use PayNL\Sdk\TotalCollection;
 
 /**
  * Class Currencies
  *
  * @package PayNL\Sdk\Model
  */
-class Currencies implements ModelInterface, Countable, ArrayAccess, IteratorAggregate
+class Currencies extends TotalCollection implements ModelInterface
 {
     use LinksTrait;
-
-    /**
-     * @var integer
-     */
-    protected $total = 0;
-
-    /**
-     * @var array
-     */
-    protected $currencies = [];
-
-    /**
-     * @return int
-     */
-    public function getTotal(): int
-    {
-        return $this->total;
-    }
-
-    /**
-     * @param int $total
-     *
-     * @return Currencies
-     */
-    public function setTotal(int $total): self
-    {
-        $this->total = $total;
-        return $this;
-    }
 
     /**
      * @return array
      */
     public function getCurrencies(): array
     {
-        return $this->currencies;
+        return $this->toArray();
     }
 
     /**
@@ -59,6 +30,9 @@ class Currencies implements ModelInterface, Countable, ArrayAccess, IteratorAggr
      */
     public function setCurrencies(array $currencies): self
     {
+        // reset the total
+        $this->clear();
+
         if (0 === count($currencies)) {
             return $this;
         }
@@ -77,57 +51,7 @@ class Currencies implements ModelInterface, Countable, ArrayAccess, IteratorAggr
      */
     public function addCurrency(Currency $currency): self
     {
-        $this->currencies[$currency->getAbbreviation()] = $currency;
-        $this->total++;
+        $this->set($currency->getAbbreviation(), $currency);
         return $this;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getIterator()
-    {
-        return new ArrayIterator($this->currencies);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetExists($offset)
-    {
-        return isset($this->currencies[$offset]);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetGet($offset)
-    {
-        return $this->currencies[$offset] ?? null;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetSet($offset, $value)
-    {
-        $this->addCurrency($value);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetUnset($offset)
-    {
-        unset($this->currencies[$offset]);
-        $this->total--;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function count()
-    {
-        return count($this->currencies);
     }
 }

--- a/src/Model/Errors.php
+++ b/src/Model/Errors.php
@@ -4,26 +4,21 @@ declare(strict_types=1);
 
 namespace PayNL\Sdk\Model;
 
-use Countable, ArrayAccess, IteratorAggregate, ArrayIterator;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * Class Errors
  *
  * @package PayNL\Sdk\Model
  */
-class Errors implements ModelInterface, Countable, ArrayAccess, IteratorAggregate
+class Errors extends ArrayCollection implements ModelInterface
 {
-    /**
-     * @var array
-     */
-    protected $errors = [];
-
     /**
      * @return array
      */
     public function getErrors(): array
     {
-        return $this->errors;
+        return $this->toArray();
     }
 
     /**
@@ -33,62 +28,10 @@ class Errors implements ModelInterface, Countable, ArrayAccess, IteratorAggregat
      */
     public function setErrors(array $errors): Errors
     {
-        $this->errors = $errors;
-        return $this;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function count(): int
-    {
-        return count($this->errors);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetExists($offset): bool
-    {
-        return isset($this->errors[$offset]);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetGet($offset)
-    {
-        return $this->errors[$offset] ?? null;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetSet($offset, $value): void
-    {
-        if (null === $offset) {
-            $this->errors[] = $value;
-            return;
+        $this->clear();
+        foreach ($errors as $key => $error) {
+            $this->set($key, $error);
         }
-
-        $this->errors[$offset] = $value;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetUnset($offset): void
-    {
-        unset($this->errors[$offset]);
-    }
-
-    /**
-     * @inheritDoc
-     *
-     * @return ArrayIterator
-     */
-    public function getIterator(): ArrayIterator
-    {
-        return new ArrayIterator($this->errors);
+        return $this;
     }
 }

--- a/src/Model/Links.php
+++ b/src/Model/Links.php
@@ -4,26 +4,21 @@ declare(strict_types=1);
 
 namespace PayNL\Sdk\Model;
 
-use Countable, ArrayAccess, IteratorAggregate, ArrayIterator;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * Class Links
  *
  * @package PayNL\Sdk\Model
  */
-class Links implements ModelInterface, Countable, ArrayAccess, IteratorAggregate
+class Links extends ArrayCollection implements ModelInterface
 {
-    /**
-     * @var array
-     */
-    protected $links = [];
-
     /**
      * @return array
      */
     public function getLinks(): array
     {
-        return $this->links;
+        return $this->toArray();
     }
 
     /**
@@ -33,6 +28,9 @@ class Links implements ModelInterface, Countable, ArrayAccess, IteratorAggregate
      */
     public function setLinks(array $links): self
     {
+        // reset
+        $this->clear();
+
         if (0 === count($links)) {
             return $this;
         }
@@ -50,57 +48,7 @@ class Links implements ModelInterface, Countable, ArrayAccess, IteratorAggregate
      */
     public function addLink(Link $link): self
     {
-        $this->links[$link->getRel()] = $link;
+        $this->set($link->getRel(), $link);
         return $this;
-    }
-
-    /**
-     * @inheritDoc
-     *
-     * @return ArrayIterator
-     */
-    public function getIterator()
-    {
-        return new ArrayIterator($this->links);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetExists($offset)
-    {
-        return isset($this->links[$offset]);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetGet($offset)
-    {
-        return $this->links[$offset] ?? null;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetSet($offset, $value)
-    {
-        $this->addLink($value);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetUnset($offset)
-    {
-        unset($this->links[$offset]);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function count()
-    {
-        return count($this->links);
     }
 }

--- a/src/Model/PaymentMethods.php
+++ b/src/Model/PaymentMethods.php
@@ -4,52 +4,23 @@ declare(strict_types=1);
 
 namespace PayNL\Sdk\Model;
 
-use Countable, ArrayAccess, IteratorAggregate, ArrayIterator;
+use PayNL\Sdk\TotalCollection;
 
 /**
  * Class PaymentMethods
  *
  * @package PayNL\Sdk\Model
  */
-class PaymentMethods implements ModelInterface, Countable, ArrayAccess, IteratorAggregate
+class PaymentMethods extends TotalCollection implements ModelInterface
 {
     use LinksTrait;
-
-    /**
-     * @var integer
-     */
-    protected $total = 0;
-
-    /**
-     * @var array
-     */
-    protected $paymentMethods = [];
-
-    /**
-     * @return integer
-     */
-    public function getTotal(): int
-    {
-        return $this->total;
-    }
-
-    /**
-     * @param integer $total
-     *
-     * @return PaymentMethods
-     */
-    public function setTotal(int $total): self
-    {
-        $this->total = $total;
-        return $this;
-    }
 
     /**
      * @return array
      */
     public function getPaymentMethods(): array
     {
-        return $this->paymentMethods;
+        return $this->toArray();
     }
 
     /**
@@ -59,12 +30,12 @@ class PaymentMethods implements ModelInterface, Countable, ArrayAccess, Iterator
      */
     public function setPaymentMethods(array $paymentMethods): self
     {
+        // reset the total
+        $this->clear();
+
         if (0 === count($paymentMethods)) {
             return $this;
         }
-
-        // reset the total
-        $this->total = 0;
 
         foreach ($paymentMethods as $paymentMethod) {
             $this->addPaymentMethod($paymentMethod);
@@ -72,59 +43,14 @@ class PaymentMethods implements ModelInterface, Countable, ArrayAccess, Iterator
         return $this;
     }
 
+    /**
+     * @param PaymentMethod $paymentMethod
+     *
+     * @return PaymentMethods
+     */
     public function addPaymentMethod(PaymentMethod $paymentMethod): self
     {
-        $this->paymentMethods[$paymentMethod->getId()] = $paymentMethod;
-        $this->total++;
+        $this->set($paymentMethod->getId(), $paymentMethod);
         return $this;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getIterator()
-    {
-        return new ArrayIterator($this->paymentMethods);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetExists($offset)
-    {
-        return isset($this->paymentMethods[$offset]);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetGet($offset)
-    {
-        return $this->paymentMethods[$offset] ?? null;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetSet($offset, $value)
-    {
-        $this->addPaymentMethod($value);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetUnset($offset)
-    {
-        unset($this->paymentMethods[$offset]);
-        $this->total--;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function count()
-    {
-        return count($this->paymentMethods);
     }
 }

--- a/src/Model/Services.php
+++ b/src/Model/Services.php
@@ -4,52 +4,23 @@ declare(strict_types=1);
 
 namespace PayNL\Sdk\Model;
 
-use Countable, ArrayAccess, IteratorAggregate, ArrayIterator;
+use PayNL\Sdk\TotalCollection;
 
 /**
  * Class Services
  *
  * @package PayNL\Sdk\Model
  */
-class Services implements ModelInterface, Countable, ArrayAccess, IteratorAggregate
+class Services extends TotalCollection implements ModelInterface
 {
     use LinksTrait;
-
-    /**
-     * @var integer
-     */
-    protected $total = 0;
-
-    /**
-     * @var array
-     */
-    protected $services = [];
-
-    /**
-     * @return int
-     */
-    public function getTotal(): int
-    {
-        return $this->total;
-    }
-
-    /**
-     * @param int $total
-     *
-     * @return Services
-     */
-    public function setTotal(int $total): self
-    {
-        $this->total = $total;
-        return $this;
-    }
 
     /**
      * @return array
      */
     public function getServices(): array
     {
-        return $this->services;
+        return $this->toArray();
     }
 
     /**
@@ -59,6 +30,9 @@ class Services implements ModelInterface, Countable, ArrayAccess, IteratorAggreg
      */
     public function setServices(array $services): self
     {
+        // reset the total
+        $this->clear();
+
         if (0 === count($services)) {
             return $this;
         }
@@ -77,57 +51,7 @@ class Services implements ModelInterface, Countable, ArrayAccess, IteratorAggreg
      */
     public function addService(Service $service): self
     {
-        $this->services[$service->getId()] = $service;
-        $this->total++;
+        $this->set($service->getId(), $service);
         return $this;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getIterator()
-    {
-        return new ArrayIterator($this->services);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetExists($offset)
-    {
-        return isset($this->services[$offset]);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetGet($offset)
-    {
-        return $this->services[$offset] ?? null;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetSet($offset, $value)
-    {
-        return $this->addService($value);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetUnset($offset)
-    {
-        unset($this->services[$offset]);
-        $this->total--;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function count()
-    {
-        return count($this->services);
     }
 }

--- a/src/Model/Status.php
+++ b/src/Model/Status.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PayNL\Sdk\Model;
 
 use DateTime;
+use PayNL\Sdk\Exception\InvalidArgumentException;
 
 /**
  * Class Status
@@ -36,7 +37,7 @@ class Status implements ModelInterface
     /**
      * @return string
      */
-    public function getCode(): string
+    public function getCode()
     {
         return $this->code;
     }
@@ -44,10 +45,21 @@ class Status implements ModelInterface
     /**
      * @param string $code
      *
+     * @throws InvalidArgumentException
+     *
      * @return Status
      */
-    public function setCode(string $code): Status
+    public function setCode($code): Status
     {
+        if (false === is_string($code)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Argument given to %s is not a string',
+                    __METHOD__
+                )
+            );
+        }
+
         $this->code = $code;
         return $this;
     }

--- a/src/Model/Terminals.php
+++ b/src/Model/Terminals.php
@@ -4,52 +4,23 @@ declare(strict_types=1);
 
 namespace PayNL\Sdk\Model;
 
-use Countable, ArrayAccess, IteratorAggregate, ArrayIterator;
+use PayNL\Sdk\TotalCollection;
 
 /**
  * Class Terminals
  *
  * @package PayNL\Sdk\Model
  */
-class Terminals implements ModelInterface, Countable, ArrayAccess, IteratorAggregate
+class Terminals extends TotalCollection implements ModelInterface
 {
     use LinksTrait;
-
-    /**
-     * @var integer
-     */
-    protected $total = 0;
-
-    /**
-     * @var array
-     */
-    protected $terminals = [];
-
-    /**
-     * @return int
-     */
-    public function getTotal(): int
-    {
-        return $this->total;
-    }
-
-    /**
-     * @param int $total
-     *
-     * @return Terminals
-     */
-    public function setTotal(int $total): self
-    {
-        $this->total = $total;
-        return $this;
-    }
 
     /**
      * @return array
      */
     public function getTerminals(): array
     {
-        return $this->terminals;
+        return $this->toArray();
     }
 
     /**
@@ -59,6 +30,9 @@ class Terminals implements ModelInterface, Countable, ArrayAccess, IteratorAggre
      */
     public function setTerminals(array $terminals): self
     {
+        // reset the total
+        $this->clear();
+
         if (0 === count($terminals)) {
             return $this;
         }
@@ -77,57 +51,7 @@ class Terminals implements ModelInterface, Countable, ArrayAccess, IteratorAggre
      */
     public function addTerminal(Terminal $terminal): self
     {
-        $this->terminals[$terminal->getId()] = $terminal;
-        $this->total++;
+        $this->set($terminal->getId(), $terminal);
         return $this;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getIterator()
-    {
-        return new ArrayIterator($this->terminals);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetExists($offset)
-    {
-        return isset($this->terminals[$offset]);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetGet($offset)
-    {
-        return $this->terminals[$offset] ?? null;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetSet($offset, $value)
-    {
-        $this->addTerminal($value);
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function offsetUnset($offset)
-    {
-        unset($this->terminals[$offset]);
-        $this->total--;
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function count()
-    {
-        return count($this->terminals);
     }
 }

--- a/src/Model/TransactionStatus.php
+++ b/src/Model/TransactionStatus.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayNL\Sdk\Model;
+
+use PayNL\Sdk\Exception\InvalidArgumentException;
+use PayNL\Sdk\Exception\RuntimeException;
+use ReflectionClass, ReflectionException;
+
+/**
+ * Class Status
+ *
+ * @package PayNL\Sdk\Model
+ */
+class TransactionStatus extends Status
+{
+    /*
+     * Status code constant definitions
+     */
+    public const STATUS_CANCELLED          = -90;
+    public const STATUS_PARTIALLY_REFUNDED = -82;
+    public const STATUS_REFUNDED_CUSTOMER  = -81;
+    public const STATUS_EXPIRED            = -80;
+    public const STATUS_REFUNDING          = -72;
+    public const STATUS_CHARGEBACK         = -71;
+    public const STATUS_DENIED             = -63;
+    public const STATUS_FAILURE            = -60;
+    public const STATUS_INVALID_AMOUNT     = -51;
+    public const STATUS_UNKNOWN            = 0;
+    public const STATUS_INITIALIZED        = 20;
+    public const STATUS_PROCESSING         = 25;
+    public const STATUS_PENDING1           = 50;
+    public const STATUS_SUBSCRIPTION_OPEN  = 60;
+    public const STATUS_PENDING2           = 70;
+    public const STATUS_PROCESSED          = 75;
+    public const STATUS_CONFIRMED          = 76;
+    public const STATUS_PARTIALLY_PAID     = 80;
+    public const STATUS_VERIFY             = 85;
+    public const STATUS_PENDING3           = 90;
+    public const STATUS_AUTHORIZED         = 95;
+    public const STATUS_PARTIALLY_ACCEPTED = 97;
+    public const STATUS_PAID               = 100;
+
+    /**
+     * @throws ReflectionException
+     *
+     * @return array
+     */
+    public function getAllowedStatus(): array
+    {
+        $ref = new ReflectionClass(static::class);
+        return array_filter($ref->getConstants(), static function (string $key) {
+            return 0 === strpos($key, 'STATUS_');
+        }, ARRAY_FILTER_USE_KEY);
+    }
+
+    /**
+     * @param mixed $code
+     *
+     * @throws InvalidArgumentException
+     * @throws RuntimeException
+     *
+     * @return Status
+     */
+    public function setCode($code): Status
+    {
+        if (true === is_string($code)) {
+            $code = (int)$code;
+        } elseif (false === is_int($code)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Given code must be an integer or a string containing a number, %s given',
+                    is_object($code) ? get_class($code) : gettype($code)
+                )
+            );
+        }
+
+        try {
+            $allowedStatus = $this->getAllowedStatus();
+        } catch (ReflectionException $re) {
+            throw new RuntimeException('Can not get allowed status');
+        }
+
+        if (false === in_array($code, $allowedStatus, true)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Code "%s" is not allowed',
+                    $code
+                )
+            );
+        }
+
+        return parent::setCode((string)$code);
+    }
+
+    /**
+     * @return integer
+     */
+    public function getCode()
+    {
+        return (int)parent::getCode();
+    }
+
+    /**
+     * @param mixed $constantNameOrCode
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return bool
+     */
+    public function is($constantNameOrCode): bool
+    {
+        if (true === is_string($constantNameOrCode)) {
+            $constantNameOrCode = constant(static::class . '::' . $constantNameOrCode);
+        } elseif (false === is_int($constantNameOrCode)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Argument given to %s must be a string or an integer, %s given',
+                    __METHOD__,
+                    is_object($constantNameOrCode) === true ? get_class($constantNameOrCode) : gettype($constantNameOrCode)
+                )
+            );
+        }
+
+        return $this->getCode() === $constantNameOrCode;
+    }
+}

--- a/src/Model/TransactionStatus.php
+++ b/src/Model/TransactionStatus.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PayNL\Sdk\Model;
 
 use PayNL\Sdk\Exception\InvalidArgumentException;
-use PayNL\Sdk\Exception\RuntimeException;
 use ReflectionClass, ReflectionException;
 
 /**

--- a/src/Model/TransactionStatus.php
+++ b/src/Model/TransactionStatus.php
@@ -59,7 +59,7 @@ class TransactionStatus extends Status
      * @param mixed $code
      *
      * @throws InvalidArgumentException
-     * @throws RuntimeException
+     * @throws ReflectionException
      *
      * @return Status
      */
@@ -76,11 +76,7 @@ class TransactionStatus extends Status
             );
         }
 
-        try {
-            $allowedStatus = $this->getAllowedStatus();
-        } catch (ReflectionException $re) {
-            throw new RuntimeException('Can not get allowed status');
-        }
+        $allowedStatus = $this->getAllowedStatus();
 
         if (false === in_array($code, $allowedStatus, true)) {
             throw new InvalidArgumentException(

--- a/src/Request/AbstractRequest.php
+++ b/src/Request/AbstractRequest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PayNL\Sdk\Request;
 
-use RuntimeException;
 use PayNL\GuzzleHttp\{
     Client,
     Psr7\Request,
@@ -14,6 +13,7 @@ use PayNL\GuzzleHttp\{
 use PayNL\Sdk\{
     DebugTrait,
     Exception\ExceptionInterface,
+    Exception\RuntimeException,
     Response,
     Exception\InvalidArgumentException,
     Filter\FilterInterface,
@@ -295,7 +295,7 @@ abstract class AbstractRequest implements RequestInterface
         try {
             $guzzleClient = $this->getClient();
             if (false === ($guzzleClient instanceof Client)) {
-                throw new RuntimeException('No HTTP client found');
+                throw new RuntimeException('No HTTP client found', 500);
             }
             $guzzleResponse = $guzzleClient->send($guzzleRequest);
 

--- a/src/Response.php
+++ b/src/Response.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PayNL\Sdk;
 
 use PayNL\Sdk\Exception\InvalidArgumentException;
+use PayNL\Sdk\Model\Errors;
 
 /**
  * Class Response
@@ -164,5 +165,38 @@ class Response
     {
         $this->body = $body;
         return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasErrors(): bool
+    {
+        return (true === in_array($this->getStatusCode(), range(400, 599), true)
+            || $this->getBody() instanceof Errors
+        );
+    }
+
+    /**
+     * Retrieve the current errors as a string for the request if there are any
+     *
+     * @return string
+     */
+    public function getErrors(): string
+    {
+        if (true === $this->hasErrors()) {
+            $body = $this->getBody();
+            if ($body instanceof Errors) {
+                return implode("\n", $body->map(static function ($element) {
+                    return sprintf(
+                        '%s (%d)',
+                        $element['message'],
+                        $element['code']
+                    );
+                })->toArray());
+            }
+            return $body;
+        }
+        return '';
     }
 }

--- a/src/TotalCollection.php
+++ b/src/TotalCollection.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PayNL\Sdk;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * Class TotalCollection
+ *
+ * @package PayNL\Sdk
+ */
+class TotalCollection extends ArrayCollection
+{
+    /**
+     * @var integer
+     */
+    protected $total = 0;
+
+    /**
+     * @return int
+     */
+    public function getTotal(): int
+    {
+        return $this->total;
+    }
+
+    /**
+     * @param int $total
+     *
+     * @return TotalCollection
+     */
+    public function setTotal(int $total): self
+    {
+        $this->total = $total;
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set($key, $value): void
+    {
+        parent::set($key, $value);
+        $this->setTotal($this->getTotal() + 1);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function add($element): bool
+    {
+        $result =  parent::add($element);
+        if (true === $result) {
+            $this->setTotal($this->getTotal() + 1);
+        }
+        return $result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function remove($key)
+    {
+        $result = parent::remove($key);
+        if (null !== $result) {
+            $this->setTotal($this->getTotal() - 1);
+        }
+        return $result;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function removeElement($element)
+    {
+        $result = parent::removeElement($element);
+        if (true === $result) {
+            $this->setTotal($this->getTotal() - 1);
+        }
+        return $result;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clear(): void
+    {
+        parent::clear();
+        $this->setTotal(0);
+    }
+}

--- a/tests/unit/ConfigTest.php
+++ b/tests/unit/ConfigTest.php
@@ -88,11 +88,13 @@ class ConfigTest extends UnitTest
     {
         Config::getInstance()->load([
             Config::KEY_API_URL  => 'https://rest.somehost.topleveldomain',
+            Config::KEY_VERSION  => 1,
             Config::KEY_USERNAME => 'piet',
             Config::KEY_PASSWORD => 'blaatschaap',
         ]);
 
         verify(Config::getInstance()->get(Config::KEY_API_URL))->notEmpty();
+        verify(Config::getInstance()->get(Config::KEY_VERSION))->notEmpty();
         verify(Config::getInstance()->get(Config::KEY_USERNAME))->notEmpty();
         verify(Config::getInstance()->get(Config::KEY_PASSWORD))->notEmpty();
     }
@@ -104,6 +106,20 @@ class ConfigTest extends UnitTest
     {
         $this->expectException(InvalidArgumentException::class);
         Config::getInstance()->load([
+            Config::KEY_VERSION  => 1,
+            Config::KEY_USERNAME => 'piet',
+            Config::KEY_PASSWORD => 'blaatschaap',
+        ]);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItThrowsAnExceptionWhenVersionIsNotSet(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Config::getInstance()->load([
+            Config::KEY_API_URL  => 'https://rest.somehost.topleveldomain',
             Config::KEY_USERNAME => 'piet',
             Config::KEY_PASSWORD => 'blaatschaap',
         ]);
@@ -117,6 +133,7 @@ class ConfigTest extends UnitTest
         $this->expectException(InvalidArgumentException::class);
         Config::getInstance()->load([
             Config::KEY_API_URL  => 'https://rest.somehost.topleveldomain',
+            Config::KEY_VERSION  => 1,
             Config::KEY_PASSWORD => 'blaatschaap',
         ]);
     }
@@ -129,6 +146,7 @@ class ConfigTest extends UnitTest
         $this->expectException(InvalidArgumentException::class);
         Config::getInstance()->load([
             Config::KEY_API_URL  => 'https://rest.somehost.topleveldomain',
+            Config::KEY_VERSION  => 1,
             Config::KEY_USERNAME => 'piet',
         ]);
     }
@@ -141,6 +159,7 @@ class ConfigTest extends UnitTest
         $this->expectException(UnexpectedValueException::class);
         Config::getInstance()->load([
             Config::KEY_API_URL  => 'https://rest.somehost.topleveldomain',
+            Config::KEY_VERSION  => 1,
             Config::KEY_USERNAME => 'piet',
             Config::KEY_PASSWORD => 'blaatschaap',
             1 => 'value',
@@ -156,6 +175,7 @@ class ConfigTest extends UnitTest
     {
         Config::getInstance()->load([
             Config::KEY_API_URL  => 'https://rest.somehost.topleveldomain',
+            Config::KEY_VERSION  => 1,
             Config::KEY_USERNAME => 'piet',
             Config::KEY_PASSWORD => 'blaatschaap',
         ]);
@@ -173,10 +193,33 @@ class ConfigTest extends UnitTest
      *
      * @return void
      */
+    public function testItCanContainAVersion(): void
+    {
+        Config::getInstance()->load([
+            Config::KEY_API_URL  => 'https://rest.somehost.topleveldomain',
+            Config::KEY_VERSION  => 1,
+            Config::KEY_USERNAME => 'piet',
+            Config::KEY_PASSWORD => 'blaatschaap',
+        ]);
+
+        verify(Config::getInstance()->getVersion())->equals(1);
+        Config::getInstance()->set(Config::KEY_VERSION, 2);
+        verify(Config::getInstance()->getVersion())->equals(2);
+
+        Config::getInstance()->set('wrong_version_key', 3);
+        verify(Config::getInstance()->getVersion())->equals(2);
+    }
+
+    /**
+     * @depends testItCanLoadAConfigurationArray
+     *
+     * @return void
+     */
     public function testItCanContainAnUsername(): void
     {
         Config::getInstance()->load([
             Config::KEY_API_URL  => 'https://rest.somehost.topleveldomain',
+            Config::KEY_VERSION  => 1,
             Config::KEY_USERNAME => 'piet',
             Config::KEY_PASSWORD => 'blaatschaap',
         ]);
@@ -198,6 +241,7 @@ class ConfigTest extends UnitTest
     {
         Config::getInstance()->load([
             Config::KEY_API_URL  => 'https://rest.somehost.topleveldomain',
+            Config::KEY_VERSION  => 1,
             Config::KEY_USERNAME => 'piet',
             Config::KEY_PASSWORD => 'blaatschaap',
         ]);

--- a/tests/unit/Hydrator/DirectdebitTest.php
+++ b/tests/unit/Hydrator/DirectdebitTest.php
@@ -71,13 +71,13 @@ class DirectdebitTest extends UnitTest
                 'owner' => 'J. the Hutt',
             ],
             'status'           => [
-                'code'   =>  94,
+                'code'   =>  '94',
                 'name'   =>  'Verwerkt',
                 'date'   =>  null,
                 'reason' =>  '',
             ],
             'declined'         => [
-                'code'   => -72,
+                'code'   => '-72',
                 'name'   => 'Blaatschaap',
                 'date'   => null,
                 'reason' => 'zomaar',
@@ -116,7 +116,7 @@ class DirectdebitTest extends UnitTest
                 'owner' => 'J. the Hutt',
             ],
             'status'           => [
-                'code'   =>  94,
+                'code'   =>  '94',
                 'name'   =>  'Verwerkt',
                 'date'   =>  null,
                 'reason' =>  '',

--- a/tests/unit/Hydrator/RefundTest.php
+++ b/tests/unit/Hydrator/RefundTest.php
@@ -42,6 +42,8 @@ class RefundTest extends UnitTest
     }
 
     /**
+     * @throws Exception
+     *
      * @return void
      */
     public function testItShouldAcceptARefundModel(): void
@@ -51,6 +53,8 @@ class RefundTest extends UnitTest
     }
 
     /**
+     * @throws Exception
+     *
      * @return void
      */
     public function testItThrowsAnExceptionWhenAWrongInstanceGiven(): void
@@ -82,7 +86,7 @@ class RefundTest extends UnitTest
                 'owner'  => 'S. McDuck',
             ], new BankAccount()),
             'status'           => (new StatusHydrator())->hydrate([
-                'code' => 316,
+                'code' => '316',
                 'name' => 'Processed',
             ], new Status()),
             'products'         => [
@@ -148,7 +152,7 @@ class RefundTest extends UnitTest
                 'owner'  => 'S. McDuck',
             ], new BankAccount()),
             'status'           => (new StatusHydrator())->hydrate([
-                'code' => 316,
+                'code' => '316',
                 'name' => 'Processed',
             ], new Status()),
             'products'         => [

--- a/tests/unit/Hydrator/StatusTest.php
+++ b/tests/unit/Hydrator/StatusTest.php
@@ -10,6 +10,7 @@ use PayNL\Sdk\Hydrator\Status as StatusHydrator;
 use PayNL\Sdk\Model\Status;
 use Zend\Hydrator\HydratorInterface;
 use PayNL\Sdk\DateTime;
+use Exception;
 
 /**
  * Class StatusTest
@@ -28,6 +29,8 @@ class StatusTest extends UnitTest
     }
 
     /**
+     * @throws Exception
+     *
      * @return void
      */
     public function testItShouldAcceptAStatusModel(): void
@@ -37,6 +40,8 @@ class StatusTest extends UnitTest
     }
 
     /**
+     * @throws Exception
+     *
      * @return void
      */
     public function testItThrowsAnExceptionWhenAWrongInstanceGiven(): void
@@ -48,20 +53,22 @@ class StatusTest extends UnitTest
     }
 
     /**
+     * @throws Exception
+     *
      * @return void
      */
     public function testItShouldCorrectlyFillModel(): void
     {
         $hydrator = new StatusHydrator();
         $status = $hydrator->hydrate([
-            'code'   => 316,
+            'code'   => '100',
             'name'   => 'Processed',
             'date'   => DateTime::createFromFormat('Y-m-d', '2019-09-11'),
             'reason' => 'Because it can!',
         ], new Status());
 
         expect($status->getCode())->string();
-        expect($status->getCode())->equals('316');
+        expect($status->getCode())->equals('100');
         expect($status->getName())->string();
         expect($status->getName())->equals('Processed');
         expect($status->getDate())->isInstanceOf(DateTime::class);
@@ -70,13 +77,15 @@ class StatusTest extends UnitTest
     }
 
     /**
+     * @throws Exception
+     *
      * @return void
      */
     public function testItCanExtract(): void
     {
         $hydrator = new StatusHydrator();
         $status = $hydrator->hydrate([
-            'code'   => 316,
+            'code'   => '75',
             'name'   => 'Processed',
             'date'   => DateTime::createFromFormat('Y-m-d', '2019-09-11'),
             'reason' => 'Because it can!',
@@ -90,7 +99,7 @@ class StatusTest extends UnitTest
         verify($data)->hasKey('reason');
 
         expect($data['code'])->string();
-        expect($data['code'])->equals('316');
+        expect($data['code'])->equals('75');
         expect($data['name'])->string();
         expect($data['name'])->equals('Processed');
         expect($data['date'])->isInstanceOf(DateTime::class);

--- a/tests/unit/Hydrator/TransactionTest.php
+++ b/tests/unit/Hydrator/TransactionTest.php
@@ -17,7 +17,7 @@ use PayNL\Sdk\Hydrator\{
 };
 use PayNL\Sdk\Model\{
     Transaction,
-    Status,
+    TransactionStatus,
     PaymentMethod,
     BankAccount,
     Address,
@@ -84,7 +84,7 @@ class TransactionTest extends UnitTest
             'id' => 484512854,
             'serviceId' => 'SL-1000-0001',
             'status' => [
-                'code'   => 316,
+                'code'   => TransactionStatus::STATUS_PROCESSED,
                 'name'   => 'processed',
                 'date'   => DateTime::createFromFormat('Y-m-d', '2019-09-11'),
                 'reason' => 'Just because...'
@@ -196,7 +196,7 @@ class TransactionTest extends UnitTest
         expect($transaction->getId())->equals('484512854');
         expect($transaction->getServiceId())->string();
         expect($transaction->getServiceId())->equals('SL-1000-0001');
-        expect($transaction->getStatus())->isInstanceOf(Status::class);
+        expect($transaction->getStatus())->isInstanceOf(TransactionStatus::class);
         expect($transaction->getReturnUrl())->string();
         expect($transaction->getReturnUrl())->equals('https://www.pay.nl/return-url');
         expect($transaction->getExchangeUrl())->string();
@@ -249,11 +249,11 @@ class TransactionTest extends UnitTest
             'id' => 484512854,
             'serviceId' => 'SL-1000-0001',
             'status' => (new StatusHydrator())->hydrate([
-                'code'   => 316,
+                'code'   => TransactionStatus::STATUS_PROCESSED,
                 'name'   => 'processed',
                 'date'   => DateTime::createFromFormat('Y-m-d', '2019-09-11'),
                 'reason' => 'Just because...'
-            ], new Status()),
+            ], new TransactionStatus()),
             'returnUrl' => 'https://www.pay.nl/return-url',
             'exchangeUrl' => 'https://www.pay.nl/exchange-url',
             'reference' => '',
@@ -392,7 +392,7 @@ class TransactionTest extends UnitTest
         expect($data['id'])->equals('484512854');
         expect($data['serviceId'])->string();
         expect($data['serviceId'])->equals('SL-1000-0001');
-        expect($data['status'])->isInstanceOf(Status::class);
+        expect($data['status'])->isInstanceOf(TransactionStatus::class);
         expect($data['returnUrl'])->string();
         expect($data['returnUrl'])->equals('https://www.pay.nl/return-url');
         expect($data['exchangeUrl'])->string();

--- a/tests/unit/Model/CurrenciesTest.php
+++ b/tests/unit/Model/CurrenciesTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Tests\Unit\PayNL\Sdk\Model;
 
 use Codeception\Test\Unit as UnitTest;
+use PayNL\Sdk\TotalCollection;
 use PayNL\Sdk\Model\{
     ModelInterface,
     Links,
     Currency,
     Currencies
 };
-use PayNL\Sdk\DateTime;
 use PayNL\Sdk\Hydrator\{
     Simple as SimpleHydrator,
     Links as LinksHydrator
@@ -30,6 +30,9 @@ class CurrenciesTest extends UnitTest
      */
     protected $currencies;
 
+    /**
+     * @return void
+     */
     public function _before(): void
     {
         $this->currencies = new Currencies();
@@ -41,6 +44,14 @@ class CurrenciesTest extends UnitTest
     public function testItIsAModel(): void
     {
         verify($this->currencies)->isInstanceOf(ModelInterface::class);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItIsATotalCollection(): void
+    {
+        verify($this->currencies)->isInstanceOf(TotalCollection::class);
     }
 
     /**
@@ -90,10 +101,12 @@ class CurrenciesTest extends UnitTest
     public function testItCanAddCurrency(): void
     {
         verify(method_exists($this->currencies, 'addCurrency'))->true();
-        verify($this->currencies->addCurrency((new SimpleHydrator())->hydrate([
+        /** @var Currency $currency */
+        $currency = (new SimpleHydrator())->hydrate([
             'abbreviation' => 'EUR',
             'description'  => 'Euro',
-        ], new Currency())))->isInstanceOf(Currencies::class);
+        ], new Currency());
+        verify($this->currencies->addCurrency($currency))->isInstanceOf(Currencies::class);
     }
 
     /**
@@ -214,7 +227,7 @@ class CurrenciesTest extends UnitTest
         verify($this->currencies['EUR'])->isInstanceOf(Currency::class);
 
         // offsetSet
-        $this->currencies['EUR'] = (new SimpleHydrator())->hydrate([
+        $this->currencies['AUD'] = (new SimpleHydrator())->hydrate([
             'abbreviation' => 'AUD',
             'description'  => 'Australian Dollar',
         ], new Currency());

--- a/tests/unit/Model/ErrorsTest.php
+++ b/tests/unit/Model/ErrorsTest.php
@@ -10,6 +10,7 @@ use PayNL\Sdk\Model\{
     Errors
 };
 use JsonSerializable, Countable, ArrayAccess, IteratorAggregate;
+use Doctrine\Common\Collections\ArrayCollection;
 
 /**
  * Class ErrorsTest
@@ -34,6 +35,14 @@ class ErrorsTest extends UnitTest
     public function testItIsAModel(): void
     {
         verify($this->errors)->isInstanceOf(ModelInterface::class);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItIsADoctrineArrayCollection(): void
+    {
+        verify($this->errors)->isInstanceOf(ArrayCollection::class);
     }
 
     /**

--- a/tests/unit/Model/LinksTest.php
+++ b/tests/unit/Model/LinksTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\PayNL\Sdk\Model;
 
 use Codeception\Test\Unit as UnitTest;
+use Doctrine\Common\Collections\ArrayCollection;
 use PayNL\Sdk\Model\{
     ModelInterface,
     Link,
@@ -25,6 +26,9 @@ class LinksTest extends UnitTest
      */
     protected $links;
 
+    /**
+     * @return void
+     */
     public function _before(): void
     {
         $this->links = new Links();
@@ -36,6 +40,14 @@ class LinksTest extends UnitTest
     public function testItIsAModel(): void
     {
         verify($this->links)->isInstanceOf(ModelInterface::class);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItIsATotalCollection(): void
+    {
+        verify($this->links)->isInstanceOf(ArrayCollection::class);
     }
 
     /**

--- a/tests/unit/Model/PaymentMethodsTest.php
+++ b/tests/unit/Model/PaymentMethodsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\PayNL\Sdk\Model;
 
 use Codeception\Test\Unit as UnitTest;
+use PayNL\Sdk\TotalCollection;
 use PayNL\Sdk\Model\{
     ModelInterface,
     Links,
@@ -29,6 +30,9 @@ class PaymentMethodsTest extends UnitTest
      */
     protected $paymentMethods;
 
+    /**
+     * @return void
+     */
     public function _before(): void
     {
         $this->paymentMethods = new PaymentMethods();
@@ -40,6 +44,14 @@ class PaymentMethodsTest extends UnitTest
     public function testItIsAModel(): void
     {
         verify($this->paymentMethods)->isInstanceOf(ModelInterface::class);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItIsATotalCollection(): void
+    {
+        verify($this->paymentMethods)->isInstanceOf(TotalCollection::class);
     }
 
     /**

--- a/tests/unit/Model/ServicesTest.php
+++ b/tests/unit/Model/ServicesTest.php
@@ -11,7 +11,10 @@ use PayNL\Sdk\Model\{
     Service,
     Services
 };
-use PayNL\Sdk\DateTime;
+use PayNL\Sdk\{
+    DateTime,
+    TotalCollection
+};
 use PayNL\Sdk\Hydrator\{
     Service as ServiceHydrator,
     Links as LinksHydrator
@@ -30,6 +33,9 @@ class ServicesTest extends UnitTest
      */
     protected $services;
 
+    /**
+     * @return void
+     */
     public function _before(): void
     {
         $this->services = new Services();
@@ -41,6 +47,14 @@ class ServicesTest extends UnitTest
     public function testItIsAModel(): void
     {
         verify($this->services)->isInstanceOf(ModelInterface::class);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItIsATotalCollection(): void
+    {
+        verify($this->services)->isInstanceOf(TotalCollection::class);
     }
 
     /**

--- a/tests/unit/Model/TerminalsTest.php
+++ b/tests/unit/Model/TerminalsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\PayNL\Sdk\Model;
 
 use Codeception\Test\Unit as UnitTest;
+use PayNL\Sdk\TotalCollection;
 use PayNL\Sdk\Model\{
     ModelInterface,
     Links,
@@ -29,6 +30,9 @@ class TerminalsTest extends UnitTest
      */
     protected $terminals;
 
+    /**
+     * @return void
+     */
     public function _before(): void
     {
         $this->terminals = new Terminals();
@@ -40,6 +44,14 @@ class TerminalsTest extends UnitTest
     public function testItIsAModel(): void
     {
         verify($this->terminals)->isInstanceOf(ModelInterface::class);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItIsATotalCollection(): void
+    {
+        verify($this->terminals)->isInstanceOf(TotalCollection::class);
     }
 
     /**

--- a/tests/unit/Model/TransactionStatusTest.php
+++ b/tests/unit/Model/TransactionStatusTest.php
@@ -10,7 +10,7 @@ use PayNL\Sdk\Model\{
     ModelInterface,
     TransactionStatus
 };
-use Exception, JsonSerializable, UnitTester;
+use Exception, JsonSerializable, UnitTester, ReflectionException;
 use PayNL\Sdk\Exception\InvalidArgumentException;
 
 /**
@@ -68,6 +68,8 @@ class TransactionStatusTest extends UnitTest
     /**
      * @depends testItCanGetAllowedStatus
      *
+     * @throws ReflectionException
+     *
      * @return void
      */
     public function testItCanSetACode(): void
@@ -76,6 +78,8 @@ class TransactionStatusTest extends UnitTest
     }
 
     /**
+     * @throws ReflectionException
+     *
      * @return void
      */
     public function testItThrowsAnExceptionWhenCodeIsNotAllowed(): void
@@ -87,6 +91,8 @@ class TransactionStatusTest extends UnitTest
     /**
      * @depends testItCanSetACode
      *
+     * @throws ReflectionException
+     *
      * @return void
      */
     public function testItCanGetACode(): void
@@ -96,6 +102,32 @@ class TransactionStatusTest extends UnitTest
         verify($this->status->getCode())->int();
         verify($this->status->getCode())->notEmpty();
         verify($this->status->getCode())->equals(TransactionStatus::STATUS_PAID);
+    }
+
+    /**
+     * @depends testItCanSetACode
+     * @depends testItCanGetACode
+     *
+     * @throws ReflectionException
+     *
+     * @return void
+     */
+    public function testItConvertsCodeToString(): void
+    {
+        $this->status->setCode('100');
+        verify($this->status->getCode())->int();
+        verify($this->status->getCode())->equals(100);
+    }
+
+    /**
+     * @throws ReflectionException
+     *
+     * @return void
+     */
+    public function testItThrowsAnExceptionWhenGivenCodeIsNotAStringNorAnInteger(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->status->setCode([]);
     }
 
     /**
@@ -170,6 +202,8 @@ class TransactionStatusTest extends UnitTest
     /**
      * @depends testItCanSetACode
      *
+     * @throws ReflectionException
+     *
      * @return void
      */
     public function testItCanCheckStatusByString(): void
@@ -182,6 +216,8 @@ class TransactionStatusTest extends UnitTest
 
     /**
      * @depends testItCanSetACode
+     *
+     * @throws ReflectionException
      *
      * @return void
      */

--- a/tests/unit/Model/TransactionStatusTest.php
+++ b/tests/unit/Model/TransactionStatusTest.php
@@ -8,9 +8,9 @@ use Codeception\Test\Unit as UnitTest;
 use PayNL\Sdk\DateTime;
 use PayNL\Sdk\Model\{
     ModelInterface,
-    Status
+    TransactionStatus
 };
-use Exception, JsonSerializable;
+use Exception, JsonSerializable, UnitTester;
 use PayNL\Sdk\Exception\InvalidArgumentException;
 
 /**
@@ -18,19 +18,24 @@ use PayNL\Sdk\Exception\InvalidArgumentException;
  *
  * @package Tests\Unit\PayNL\Sdk\Model
  */
-class StatusTest extends UnitTest
+class TransactionStatusTest extends UnitTest
 {
     /**
-     * @var Status
+     * @var TransactionStatus
      */
     protected $status;
+
+    /**
+     * @var UnitTester
+     */
+    protected $tester;
 
     /**
      * @return void
      */
     public function _before(): void
     {
-        $this->status = new Status();
+        $this->status = new TransactionStatus();
     }
 
     /**
@@ -52,18 +57,31 @@ class StatusTest extends UnitTest
     /**
      * @return void
      */
+    public function testItCanGetAllowedStatus(): void
+    {
+        $output = $this->tester->invokeMethod($this->status, 'getAllowedStatus');
+        verify($output)->array();
+        verify($output)->notEmpty();
+        verify($output)->containsOnly('int');
+    }
+
+    /**
+     * @depends testItCanGetAllowedStatus
+     *
+     * @return void
+     */
     public function testItCanSetACode(): void
     {
-        expect($this->status->setCode('100'))->isInstanceOf(Status::class);
+        expect($this->status->setCode(TransactionStatus::STATUS_PAID))->isInstanceOf(TransactionStatus::class);
     }
 
     /**
      * @return void
      */
-    public function testItThrowsAnExceptionWhenCodeIsNotAString(): void
+    public function testItThrowsAnExceptionWhenCodeIsNotAllowed(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $this->status->setCode(100);
+        $this->status->setCode(1000);
     }
 
     /**
@@ -73,11 +91,11 @@ class StatusTest extends UnitTest
      */
     public function testItCanGetACode(): void
     {
-        $this->status->setCode('100');
+        $this->status->setCode(TransactionStatus::STATUS_PAID);
 
-        verify($this->status->getCode())->string();
+        verify($this->status->getCode())->int();
         verify($this->status->getCode())->notEmpty();
-        verify($this->status->getCode())->equals('100');
+        verify($this->status->getCode())->equals(TransactionStatus::STATUS_PAID);
     }
 
     /**
@@ -85,7 +103,7 @@ class StatusTest extends UnitTest
      */
     public function testItCanSetAName(): void
     {
-        expect($this->status->setName('Paid'))->isInstanceOf(Status::class);
+        expect($this->status->setName('Paid'))->isInstanceOf(TransactionStatus::class);
     }
 
     /**
@@ -109,7 +127,7 @@ class StatusTest extends UnitTest
      */
     public function testItCanSetADate(): void
     {
-        expect($this->status->setDate(DateTime::now()))->isInstanceOf(Status::class);
+        expect($this->status->setDate(DateTime::now()))->isInstanceOf(TransactionStatus::class);
     }
 
     /**
@@ -132,7 +150,7 @@ class StatusTest extends UnitTest
      */
     public function testItCanSetAReason(): void
     {
-        expect($this->status->setReason('Lorem ipsum dolor sit amet'))->isInstanceOf(Status::class);
+        expect($this->status->setReason('Lorem ipsum dolor sit amet'))->isInstanceOf(TransactionStatus::class);
     }
 
     /**
@@ -147,5 +165,41 @@ class StatusTest extends UnitTest
         verify($this->status->getReason())->string();
         verify($this->status->getReason())->notEmpty();
         verify($this->status->getReason())->equals('Lorem ipsum dolor sit amet');
+    }
+
+    /**
+     * @depends testItCanSetACode
+     *
+     * @return void
+     */
+    public function testItCanCheckStatusByString(): void
+    {
+        $this->status->setCode(TransactionStatus::STATUS_PAID);
+
+        verify($this->status->is('STATUS_PAID'))->bool();
+        verify($this->status->is('STATUS_PAID'))->true();
+    }
+
+    /**
+     * @depends testItCanSetACode
+     *
+     * @return void
+     */
+    public function testItCanCheckStatusByInteger(): void
+    {
+        $this->status->setCode(TransactionStatus::STATUS_PAID);
+
+        verify($this->status->is(TransactionStatus::STATUS_PAID))->bool();
+        verify($this->status->is('STATUS_PAID'))->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItThrowsAnExceptionWhenStatusCheckGetsWrongArgument(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->status->is([]);
     }
 }

--- a/tests/unit/Model/TransactionTest.php
+++ b/tests/unit/Model/TransactionTest.php
@@ -16,7 +16,7 @@ use PayNL\Sdk\Model\Statistics;
 use PayNL\Sdk\Model\TransactionStatus;
 use PayNL\Sdk\Model\Transaction;
 use PayNL\Sdk\Model\ModelInterface;
-use Exception, JsonSerializable;
+use Exception, JsonSerializable, BadMethodCallException;
 
 /**
  * Class TransactionTest
@@ -962,5 +962,14 @@ class TransactionTest extends UnitTest
         $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_PAID);
         verify($this->transaction->isPaid())->bool();
         verify($this->transaction->isPaid())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItThrowsAnExceptionWhenMethodDoesNotExist(): void
+    {
+        $this->expectException(BadMethodCallException::class);
+        $this->transaction->test();
     }
 }

--- a/tests/unit/Model/TransactionTest.php
+++ b/tests/unit/Model/TransactionTest.php
@@ -13,7 +13,7 @@ use PayNL\Sdk\Model\Customer;
 use PayNL\Sdk\Model\PaymentMethod;
 use PayNL\Sdk\Model\Product;
 use PayNL\Sdk\Model\Statistics;
-use PayNL\Sdk\Model\Status;
+use PayNL\Sdk\Model\TransactionStatus;
 use PayNL\Sdk\Model\Transaction;
 use PayNL\Sdk\Model\ModelInterface;
 use Exception, JsonSerializable;
@@ -30,9 +30,13 @@ class TransactionTest extends UnitTest
      */
     protected $transaction;
 
+    /**
+     * @return void
+     */
     public function _before(): void
     {
         $this->transaction = new Transaction();
+        $this->transaction->setStatus(new TransactionStatus());
     }
 
     /**
@@ -102,7 +106,7 @@ class TransactionTest extends UnitTest
      */
     public function testItCanSetASStatus(): void
     {
-        expect($this->transaction->setStatus(new Status()))->isInstanceOf(Transaction::class);
+        expect($this->transaction->setStatus(new TransactionStatus()))->isInstanceOf(Transaction::class);
     }
 
     /**
@@ -112,10 +116,10 @@ class TransactionTest extends UnitTest
      */
     public function testItCanGetASStatus(): void
     {
-        $this->transaction->setStatus(new Status());
+        $this->transaction->setStatus(new TransactionStatus());
 
         verify($this->transaction->getStatus())->notEmpty();
-        verify($this->transaction->getStatus())->isInstanceOf(Status::class);
+        verify($this->transaction->getStatus())->isInstanceOf(TransactionStatus::class);
     }
 
     /**
@@ -738,5 +742,225 @@ class TransactionTest extends UnitTest
 
         verify($this->transaction->getCompany())->notEmpty();
         verify($this->transaction->getCompany())->isInstanceOf(Company::class);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsCancelled(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_CANCELLED);
+        verify($this->transaction->isCancelled())->bool();
+        verify($this->transaction->isCancelled())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsPartiallyRefunded(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_PARTIALLY_REFUNDED);
+        verify($this->transaction->isPartiallyRefunded())->bool();
+        verify($this->transaction->isPartiallyRefunded())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsRefundedCustomer(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_REFUNDED_CUSTOMER);
+        verify($this->transaction->isRefundedCustomer())->bool();
+        verify($this->transaction->isRefundedCustomer())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsExpired(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_EXPIRED);
+        verify($this->transaction->isExpired())->bool();
+        verify($this->transaction->isExpired())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsRefunding(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_REFUNDING);
+        verify($this->transaction->isRefunding())->bool();
+        verify($this->transaction->isRefunding())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsChargeback(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_CHARGEBACK);
+        verify($this->transaction->isChargeback())->bool();
+        verify($this->transaction->isChargeback())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsDenied(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_DENIED);
+        verify($this->transaction->isDenied())->bool();
+        verify($this->transaction->isDenied())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsFailure(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_FAILURE);
+        verify($this->transaction->isFailure())->bool();
+        verify($this->transaction->isFailure())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsInvalidAmount(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_INVALID_AMOUNT);
+        verify($this->transaction->isInvalidAmount())->bool();
+        verify($this->transaction->isInvalidAmount())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsInitialized(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_INITIALIZED);
+        verify($this->transaction->isInitialized())->bool();
+        verify($this->transaction->isInitialized())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsProcessing(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_PROCESSING);
+        verify($this->transaction->isProcessing())->bool();
+        verify($this->transaction->isProcessing())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsPending1(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_PENDING1);
+        verify($this->transaction->isPending())->bool();
+        verify($this->transaction->isPending())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsPending2(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_PENDING2);
+        verify($this->transaction->isPending())->bool();
+        verify($this->transaction->isPending())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsPending3(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_PENDING3);
+        verify($this->transaction->isPending())->bool();
+        verify($this->transaction->isPending())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsSubscriptionOpen(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_SUBSCRIPTION_OPEN);
+        verify($this->transaction->isSubscriptionOpen())->bool();
+        verify($this->transaction->isSubscriptionOpen())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsProcessed(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_PROCESSED);
+        verify($this->transaction->isProcessed())->bool();
+        verify($this->transaction->isProcessed())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsConfirmed(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_CONFIRMED);
+        verify($this->transaction->isConfirmed())->bool();
+        verify($this->transaction->isConfirmed())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsPartiallyPaid(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_PARTIALLY_PAID);
+        verify($this->transaction->isPartiallyPaid())->bool();
+        verify($this->transaction->isPartiallyPaid())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsVerify(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_VERIFY);
+        verify($this->transaction->isVerify())->bool();
+        verify($this->transaction->isVerify())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsAuthorized(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_AUTHORIZED);
+        verify($this->transaction->isAuthorized())->bool();
+        verify($this->transaction->isAuthorized())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsPartiallyAccepted(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_PARTIALLY_ACCEPTED);
+        verify($this->transaction->isPartiallyAccepted())->bool();
+        verify($this->transaction->isPartiallyAccepted())->true();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanCheckIsPaid(): void
+    {
+        $this->transaction->getStatus()->setCode(TransactionStatus::STATUS_PAID);
+        verify($this->transaction->isPaid())->bool();
+        verify($this->transaction->isPaid())->true();
     }
 }

--- a/tests/unit/Request/AbstractRequestTest.php
+++ b/tests/unit/Request/AbstractRequestTest.php
@@ -14,6 +14,7 @@ use PayNL\GuzzleHttp\{
 };
 use PayNL\Sdk\{
     Exception\InvalidArgumentException,
+    Exception\RuntimeException,
     Filter\FilterInterface,
     Filter\Page as PageFilter,
     Model\Errors,
@@ -23,7 +24,7 @@ use PayNL\Sdk\{
     Transformer\Simple,
     Transformer\TransformerInterface
 };
-use TypeError, UnitTester, stdClass, RuntimeException;
+use TypeError, UnitTester, stdClass;
 
 /**
  * Class AbstractRequestTest
@@ -601,16 +602,16 @@ class AbstractRequestTest extends UnitTest
      *
      * @return void
      */
-    public function testItThrowsAnExceptionWhenNoGuzzleClientIsSet(): void
+    public function testItContainsErrorsWhenNoGuzzleClientIsSet(): void
     {
-        $this->expectException(RuntimeException::class);
-
         $response = new Response();
 
         $this->anonymousClassFromAbstract->setFilters([
             new PageFilter(1),
         ])->execute($response)
         ;
+
+        verify($response->hasErrors())->true();
     }
 
     /**

--- a/tests/unit/TotalCollectionTest.php
+++ b/tests/unit/TotalCollectionTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\PayNL\Sdk;
+
+use Codeception\Test\Unit as UnitTest;
+use Doctrine\Common\Collections\ArrayCollection;
+use PayNL\Sdk\TotalCollection;
+use JsonSerializable, Countable;
+
+/**
+ * Class ConfigTest
+ *
+ * @package Tests\Unit\PayNL\Sdk
+ */
+class TotalCollectionTest extends UnitTest
+{
+    /**
+     * @var TotalCollection
+     */
+    protected $totalCollection;
+
+    /**
+     * @return void
+     */
+    public function _before(): void
+    {
+        $this->totalCollection = new TotalCollection();
+    }
+
+    /**
+     * @return void
+     */
+    public function testItIsAnArrayCollection(): void
+    {
+        verify($this->totalCollection)->isInstanceOf(ArrayCollection::class);
+    }
+
+    /**
+     * @return void
+     */
+    public function testIsItNotJsonSerializable(): void
+    {
+        verify($this->totalCollection)->isNotInstanceOf(JsonSerializable::class);
+    }
+
+    /**
+     * @return void
+     */
+    public function testItCanSetTotal(): void
+    {
+        verify(method_exists($this->totalCollection, 'setTotal'))->true();
+        verify($this->totalCollection->setTotal(3))->isInstanceOf(TotalCollection::class);
+    }
+
+    /**
+     * @depends testItCanSetTotal
+     *
+     * @return void
+     */
+    public function testItCanGetTotal(): void
+    {
+        verify(method_exists($this->totalCollection, 'getTotal'))->true();
+
+        verify($this->totalCollection->getTotal())->int();
+        verify($this->totalCollection->getTotal())->equals(0);
+
+        $this->totalCollection->setTotal(3);
+
+        verify($this->totalCollection->getTotal())->equals(3);
+    }
+
+    /**
+     * @depends testItCanSetTotal
+     * @depends testItCanGetTotal
+     *
+     * @return void
+     */
+    public function testItCanSet(): void
+    {
+        verify(method_exists($this->totalCollection, 'set'))->true();
+        verify($this->totalCollection->getTotal())->equals(0);
+
+        $this->totalCollection->set('key', 'value');
+
+        verify($this->totalCollection->getTotal())->equals(1);
+        verify($this->totalCollection)->hasKey('key');
+        verify($this->totalCollection)->contains('value');
+    }
+
+    /**
+     * @depends testItCanSetTotal
+     * @depends testItCanGetTotal
+     *
+     * @return void
+     */
+    public function testItCanAdd(): void
+    {
+        verify(method_exists($this->totalCollection, 'add'))->true();
+        verify($this->totalCollection->getTotal())->equals(0);
+
+        $this->totalCollection->add('value');
+
+        verify($this->totalCollection->getTotal())->equals(1);
+        verify($this->totalCollection)->hasKey(0);
+        verify($this->totalCollection)->contains('value');
+    }
+
+    /**
+     * @depends testItCanSetTotal
+     * @depends testItCanGetTotal
+     * @depends testItCanSet
+     *
+     * @return void
+     */
+    public function testItCanRemove(): void
+    {
+        verify(method_exists($this->totalCollection, 'remove'))->true();
+        verify($this->totalCollection->getTotal())->equals(0);
+
+        $this->totalCollection->set('key', 'some-value');
+
+        verify($this->totalCollection->getTotal())->equals(1);
+
+        $this->totalCollection->remove('key');
+
+        verify($this->totalCollection->getTotal())->equals(0);
+        verify($this->totalCollection)->hasntKey('key');
+        verify($this->totalCollection)->notContains('some-value');
+    }
+
+    /**
+     * @depends testItCanSetTotal
+     * @depends testItCanGetTotal
+     * @depends testItCanAdd
+     *
+     * @return void
+     */
+    public function testItCanRemoveElement(): void
+    {
+        verify(method_exists($this->totalCollection, 'removeElement'))->true();
+
+        verify($this->totalCollection->getTotal())->equals(0);
+
+        $this->totalCollection->add('some-value');
+
+        verify($this->totalCollection->getTotal())->equals(1);
+
+        $this->totalCollection->removeElement('some-value');
+
+        verify($this->totalCollection->getTotal())->equals(0);
+        verify($this->totalCollection)->notContains('some-value');
+    }
+
+
+    /**
+     * @depends testItCanAdd
+     *
+     * @return void
+     */
+    public function testItCanCount(): void
+    {
+        verify($this->totalCollection)->isInstanceOf(Countable::class);
+        verify(method_exists($this->totalCollection, 'count'))->true();
+
+        $this->totalCollection->add('some-value');
+
+        verify($this->totalCollection->count())->equals(1);
+        verify(count($this->totalCollection))->equals(1);
+
+    }
+
+    /**
+     * @depends testItCanGetTotal
+     * @depends testItCanCount
+     * @depends testItCanAdd
+     *
+     * @return void
+     */
+    public function testItCountAndTotalAreEqual(): void
+    {
+        $this->totalCollection->add('Element-1');
+        $this->totalCollection->add('Element-2');
+        $this->totalCollection->add('Element-3');
+
+        verify($this->totalCollection->getTotal())->equals($this->totalCollection->count());
+
+        verify($this->totalCollection->getTotal())->equals(3);
+        verify($this->totalCollection->count())->equals(3);
+    }
+
+    /**
+     * @depends testItCanSetTotal
+     * @depends testItCanGetTotal
+     * @depends testItCanAdd
+     *
+     * @return void
+     */
+    public function testItCanClear(): void
+    {
+        verify(method_exists($this->totalCollection, 'clear'))->true();
+
+        $this->totalCollection->add('some-value-1');
+        $this->totalCollection->add('some-value-2');
+        $this->totalCollection->add('some-value-3');
+
+        verify($this->totalCollection->getTotal())->equals(3);
+
+        $this->totalCollection->clear();
+
+        verify($this->totalCollection->getTotal())->equals(0);
+        verify($this->totalCollection)->isEmpty();
+    }
+}

--- a/tests/unit/Transformer/DirectdebitTest.php
+++ b/tests/unit/Transformer/DirectdebitTest.php
@@ -121,7 +121,7 @@ class DirectdebitTest extends UnitTest
                         'owner' => 'J. the Hutt',
                     ],
                     'status'           => [
-                        'code'   =>  94,
+                        'code'   =>  '94',
                         'name'   =>  'Verwerkt',
                         'date'   =>  null,
                         'reason' =>  '',
@@ -142,7 +142,7 @@ class DirectdebitTest extends UnitTest
                         'owner' => 'J. the Hutt',
                     ],
                     'status'           => [
-                        'code'   =>  94,
+                        'code'   =>  '94',
                         'name'   =>  'Verwerkt',
                         'date'   =>  null,
                         'reason' =>  '',

--- a/tests/unit/Transformer/TransactionTest.php
+++ b/tests/unit/Transformer/TransactionTest.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace Tests\Unit\PayNL\Sdk\Transformer;
 
+use Exception;
 use Codeception\Test\Unit as UnitTest;
-use PayNL\Sdk\Transformer\{
-    AbstractTransformer,
-    Transaction as TransactionTransformer,
-    TransformerInterface
+use PayNL\Sdk\{
+    DateTime,
+    Model\TransactionStatus,
+    Model\Transaction,
+    Transformer\AbstractTransformer,
+    Transformer\Transaction as TransactionTransformer,
+    Transformer\TransformerInterface
 };
-use PayNL\Sdk\DateTime;
-use PayNL\Sdk\Model\Transaction;
 
 /**
  * Class TransactionTest
@@ -74,6 +76,8 @@ class TransactionTest extends UnitTest
     }
 
     /**
+     * @throws Exception
+     *
      * @return void
      */
     public function testItCanTransformSingle(): void
@@ -82,8 +86,8 @@ class TransactionTest extends UnitTest
             'id' => 484512854,
             'serviceId' => 'SL-1000-0001',
             'status' => [
-                'code'   => 316,
-                'name'   => 'processed',
+                'code'   => TransactionStatus::STATUS_PAID,
+                'name'   => 'Paid',
                 'date'   => DateTime::createFromFormat('Y-m-d', '2019-09-11'),
                 'reason' => 'Just because...'
             ],


### PR DESCRIPTION
PAY-65: Add Own RuntimeException class + 
Introduce transaction status object to contain the specific statuses
and check for it +
Adjust status and transaction hydrator with correct comments and "sub"
hydrator for status +
Add methods to check if a transaction has a certain status +
Fix tests +
New bugs

PAY-65: Use Doctrine ArrayCollection for Errors collection object +
Adjust errors sample file +
Fix Transaction status +
Request always give errors object when format is "objects" +
Response can now check for errors and get them as a string +
Adjust tests to changes

PAY-65: Set version as own config value + 
Adjust config test

PAY-65: Refactor collection objects to own TotalCollection or Doctrine's ArrayCollection +
Adjust tests

PAY-65: Throw own RuntimeException when no Guzzle client is set +
Adjust test +
Remove obsolete use statement

![image](https://user-images.githubusercontent.com/17259827/69953141-ebe01e80-14f8-11ea-93d6-adba039ceeb7.png)
