### PR TITLE
Explicilty set supported php versions in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,10 @@
 {
   "name": "paynl/sdk",
   "require": {
-    "php-curl-class/php-curl-class": "^8.3",
+    "php": "^5.6||^7.0",
     "ext-json": "*",
-    "ext-curl": "*"
+    "ext-curl": "*",
+    "php-curl-class/php-curl-class": "^8.3"
   },
   "suggest": {
     "ext-simplexml": "*"


### PR DESCRIPTION
This also changes the order of require to be in line with current standards