### PR TITLE
Small changes in configuration and uses

### DIFF
--- a/config/config.global.php
+++ b/config/config.global.php
@@ -3,9 +3,6 @@
 declare(strict_types=1);
 
 return [
-    'api' => [
-        'url'  => 'https://rest.pay.nl/',
-    ],
     'authentication' => [
         'username' => '',
         'password' => '',

--- a/config/config.local.dist.php
+++ b/config/config.local.dist.php
@@ -3,16 +3,5 @@
 declare(strict_types=1);
 
 return [
-    'config_paths' => [
-        // add paths to custom ConfigProvider files (modules)
-    ],
-
-    'request' => [
-        'format' => 'objects' // choose one of the formats declared in \PayNL\Sdk\Request\RequestInterface
-    ],
-    'response' => [
-        'format' => 'objects' // choose one of the formats declared in \PayNL\Sdk\Response\ResponseInterface
-    ],
-
-    'debug'         => false,
+    'debug' => false,
 ];

--- a/src/Api/ConfigProvider.php
+++ b/src/Api/ConfigProvider.php
@@ -22,7 +22,7 @@ class ConfigProvider implements ConfigProviderInterface
             'service_manager' => $this->getDependencyConfig(),
             'api' => [
                 // defaults:
-                'url'     => '',
+                'url'     => 'https://rest.pay.nl/',
                 'version' => 1,
             ],
         ];

--- a/src/Validator/ConfigProvider.php
+++ b/src/Validator/ConfigProvider.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace PayNL\Sdk\Validator;
 
-use PayNL\Sdk\{Common\ManagerFactory,
-    Config\ProviderInterface as ConfigProviderInterface,
-    Validator\Qr\Decode,
-    Validator\Qr\Encode
+use PayNL\Sdk\{
+    Common\ManagerFactory,
+    Config\ProviderInterface as ConfigProviderInterface
+};
+use PayNL\Sdk\Validator\Qr\{
+    Decode,
+    Encode
 };
 
 /**


### PR DESCRIPTION
PAY-65: Move the default rest api end point to the Api module's config provider +
Make the config.local.dist as tiny as possible by just adding the highly necessary settings +
Fix the validator config provider because it's not fully PSR-12