### PR TITLE
Curly braces for offset access has been deprecated in PHP 7.4

### DIFF
--- a/src/DynamicUUID.php
+++ b/src/DynamicUUID.php
@@ -55,7 +55,7 @@ class DynamicUUID
     private static function asciiToHex($ascii) {
         $hex = '';
         for ($i = 0; $i < strlen($ascii); $i++) {
-            $byte = strtoupper(dechex(ord($ascii{$i})));
+            $byte = strtoupper(dechex(ord($ascii[$i])));
             $byte = str_repeat('0', 2 - strlen($byte)).$byte;
             $hex.=$byte."";
         }


### PR DESCRIPTION
Curly brace support has been removed in PHP 8.0 and will throw deprecation notices in PHP 7.4.