### PR TITLE
Allow php-curl-class v9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "paynl/sdk",
   "require": {
-    "php-curl-class/php-curl-class": "^8.3",
+    "php-curl-class/php-curl-class": "^8.3||^9.0",
     "ext-json": "*",
     "ext-curl": "*"
   },


### PR DESCRIPTION
It seems the only breaking changes in v9 is dropping support for older php versions. This shouldn't give any troubles when installing this sdk