### PR TITLE
Transaction::getForExchange - cast order_id to string

### DIFF
--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -363,7 +363,7 @@ class Transaction
         $input = file_get_contents('php://input');
         $xml = simplexml_load_string($input);
 
-        return self::get($xml->order_id);
+        return self::get((string) $xml->order_id);
     }
 
     /**


### PR DESCRIPTION
If not explicitly cast to string a `SimpleXMLElement` is passed instead.

This results (in my clients codebase at least) in the following error being returned by the API:

```
Paynl\\Error\\Api(code: 0):  - TransactionId is not a string at <projectroot>/vendor/paynl/sdk/src/Api/Api.php:155)
```

Client is running version `1.15.20`.

I haven't actually verified what the SDK sends to be honest so I can't say for sure if this issue is valid. But the following work-around did solve the issue for my client:

```diff
- $transaction = Transaction::getForExchange();
+ $input = file_get_contents('php://input');
+ $xml = simplexml_load_string($input);
+ $orderId = (string) $xml->order_id;
+ $transaction = Transaction::get($orderId);