### PR TITLE
PLUG-1471 - Update DebitGet to Info

### DIFF
--- a/src/Api/DirectDebit/Info.php
+++ b/src/Api/DirectDebit/Info.php
@@ -4,7 +4,7 @@ namespace Paynl\Api\DirectDebit;
 
 use Paynl\Error\Required;
 
-class DebitGet extends DirectDebit
+class Info extends DirectDebit
 {
     protected $apiTokenRequired = true;
 
@@ -41,6 +41,6 @@ class DebitGet extends DirectDebit
      */
     public function doRequest($endpoint = null, $version = null)
     {
-        return parent::doRequest('DirectDebit/debitGet');
+        return parent::doRequest('DirectDebit/info');
     }
 }

--- a/src/DirectDebit.php
+++ b/src/DirectDebit.php
@@ -85,7 +85,7 @@ class DirectDebit
 
     public static function get($mandateId)
     {
-        $api = new Api\DebitGet();
+        $api = new Api\Info();
         $api->setMandateId($mandateId);
 
         $result = $api->doRequest();


### PR DESCRIPTION
Info is een directe upgrade van de debitGet functie.

Het voegt wel een Breaking Change toe, alles in de result array is hetzelfde op 1 ding na, 
result['order'] is hernoemt in de api naar result['mandate']