### PR TITLE
Fixed PHP 8 Deprecated Functionality warning

### DIFF
--- a/src/Error/Required.php
+++ b/src/Error/Required.php
@@ -17,6 +17,6 @@ class Required extends Error
     public function __construct($message, $code = null, \Exception $previous = null)
     {
         $message = "'$message' is required";
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message, (int)$code, $previous);
     }
 }


### PR DESCRIPTION
This PR fixes "Deprecated Functionality: Exception::__construct(): Passing null to parameter #2 ($code) of type int is deprecated".