### PR TITLE
Fix types on the CurlInterface

### DIFF
--- a/src/Curl/CurlInterface.php
+++ b/src/Curl/CurlInterface.php
@@ -44,7 +44,7 @@ interface CurlInterface
      * Set Opt
      *
      * @access public
-     * @param string $option
+     * @param int $option
      * @param mixed $value
      *
      * @return boolean


### PR DESCRIPTION
Passing a string would result in a type error, as the `curl_set_opt` expects a string And the Curl class itself uses `declare(strict_types=1)`