### PR TITLE
PHP 8.4: Mark parameters as nullable.

### DIFF
--- a/src/Error/NotFound.php
+++ b/src/Error/NotFound.php
@@ -4,7 +4,7 @@ namespace Paynl\Error;
 
 class NotFound extends Error
 {
-    public function __construct($objectName, $identifier, \Exception $previous = null)
+    public function __construct($objectName, $identifier, ?\Exception $previous = null)
     {
         $message = "$objectName: '$identifier' Not found";
         parent::__construct($message, 404, $previous);

--- a/src/Error/Required.php
+++ b/src/Error/Required.php
@@ -14,7 +14,7 @@ class Required extends Error
      * @param null            $code
      * @param \Exception|null $previous
      */
-    public function __construct($message, $code = null, \Exception $previous = null)
+    public function __construct($message, $code = null, ?\Exception $previous = null)
     {
         $message = "'$message' is required";
         parent::__construct($message, (int)$code, $previous);

--- a/src/Payment.php
+++ b/src/Payment.php
@@ -48,8 +48,8 @@ class Payment
         Model\Customer $customer,
         Model\CSE $cse,
         Model\Browser $browser,
-        Model\Statistics $statistics = null,
-        Model\Order $order = null
+        ?Model\Statistics $statistics = null,
+        ?Model\Order $order = null
     ) {
         $authenticate = new Model\Authenticate();
 

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -401,7 +401,7 @@ class Transaction
      * @throws Error\Required\ApiToken
      * @throws Error\Required\ServiceId
      */
-    public static function refund($transactionId, $amount = null, $description = null, \DateTime $processDate = null, $vatPercentage = null, $currency = null)
+    public static function refund($transactionId, $amount = null, $description = null, ?\DateTime $processDate = null, $vatPercentage = null, $currency = null)
     {
         $api = new Api\Refund();
         $api->setTransactionId($transactionId);


### PR DESCRIPTION
This PR explicitly marks nullable parameters as nullable. I've just updated the parameters that have a type, to make it compabible with php 8.4.