### PR TITLE
Add reference to newest SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@
 
 ---
 
+### Version
+
+This SDK supports the older rest-api version. 
+The newest SDK (based on V3 order api) can be found here: [https://github.com/paynl/php-sdk](https://github.com/paynl/php-sdk)
+
 ### Installation
 
 This SDK uses composer.


### PR DESCRIPTION
I landed on this SDK using google and trough the aliance sdk (https://github.com/paynl/sdk-alliance). It confused me that there wasn't an sdk for the newest api. Might be good to add something to the readme explaining / pointing to the new version. 