### PR TITLE
Update composer.json - php-curl-class/php-curl-class v12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "paynl/sdk",
   "version": "2.2.4",
   "require": {
-    "php-curl-class/php-curl-class": "^8.3||^9.0||^10|^11",
+    "php-curl-class/php-curl-class": "^8.3||^9.0||^10||^11||^12",
     "ext-json": "*",
     "ext-curl": "*"
   },


### PR DESCRIPTION
php-curl-class/php-curl-class v12 drops PHP 7.4 support; no incompatible changes.

Also fixes a single pipe into a double pipe